### PR TITLE
Fix replace native alert() with confirmationService in AppHeaderComponent

### DIFF
--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -142,14 +142,16 @@ export class AppHeaderComponent implements OnInit {
             this.languageSuccessHandler(response, language);
           } else {
             this.confirmationService.alert(
-              this.currentLanguageSet.alerts.info.langNotDefinesd,
+              this.currentLanguageSet?.alerts?.info?.langNotDefinesd ??
+                'Selected language is not defined',
               'error'
             );
           }
         },
         error => {
           this.confirmationService.alert(
-            this.currentLanguageSet.alerts.info.comingUpWithThisLang +
+            (this.currentLanguageSet?.alerts?.info?.comingUpWithThisLang ??
+              'Selected language is coming up with') +
               ' ' +
               language,
             'error'
@@ -168,9 +170,11 @@ export class AppHeaderComponent implements OnInit {
   languageSuccessHandler(response: any, language: any) {
     if (response === undefined) {
       this.confirmationService.alert(
-        this.currentLanguageSet.alerts.info.langNotDefinesd,
+        this.currentLanguageSet?.alerts?.info?.langNotDefinesd ??
+          'Selected language is not defined',
         'error'
       );
+      return;
     }
 
     if (response[language] !== undefined) {
@@ -190,7 +194,8 @@ export class AppHeaderComponent implements OnInit {
       this.rolenavigation();
     } else {
       this.confirmationService.alert(
-        this.currentLanguageSet.alerts.info.comingUpWithThisLang +
+        (this.currentLanguageSet?.alerts?.info?.comingUpWithThisLang ??
+          'Selected language is coming up with') +
           ' ' +
           language,
         'error'

--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -141,14 +141,18 @@ export class AppHeaderComponent implements OnInit {
           if (response !== undefined && response !== null) {
             this.languageSuccessHandler(response, language);
           } else {
-            alert(this.currentLanguageSet.alerts.info.langNotDefinesd);
+            this.confirmationService.alert(
+              this.currentLanguageSet.alerts.info.langNotDefinesd,
+              'error'
+            );
           }
         },
         error => {
-          alert(
+          this.confirmationService.alert(
             this.currentLanguageSet.alerts.info.comingUpWithThisLang +
               ' ' +
-              language
+              language,
+            'error'
           );
         }
       );
@@ -162,9 +166,11 @@ export class AppHeaderComponent implements OnInit {
   }
 
   languageSuccessHandler(response: any, language: any) {
-    console.log('language is ', response);
     if (response === undefined) {
-      alert(this.currentLanguageSet.alerts.info.langNotDefinesd);
+      this.confirmationService.alert(
+        this.currentLanguageSet.alerts.info.langNotDefinesd,
+        'error'
+      );
     }
 
     if (response[language] !== undefined) {
@@ -183,10 +189,11 @@ export class AppHeaderComponent implements OnInit {
       this.http_service.getCurrentLanguage(response[language]);
       this.rolenavigation();
     } else {
-      alert(
+      this.confirmationService.alert(
         this.currentLanguageSet.alerts.info.comingUpWithThisLang +
           ' ' +
-          language
+          language,
+        'error'
       );
     }
   }


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A

`AppHeaderComponent` already injects `ConfirmationService` but was using native browser `alert()` in 4 places for language load errors. This is inconsistent with the rest of the app where `ConfirmationService.alert()` is the standard pattern for user-facing error messages.

Also removes a leftover `console.log('language is ', response)` debug statement from `languageSuccessHandler`.

Closes #137 {https://github.com/PSMRI/AMRIT/issues/137}

---

## Type of Change

- [x]  🐞 Bug fix (non-breaking change which resolves an issue)
- [x]  🎨 UI/UX (changes that affect the user interface)
- [x] 🧹 Chore (miscellaneous changes that don't modify src or test files)

---

## Additional Information

**Testing:**
- Verified via grep: no bare `alert()` calls remain in the file
- `ng lint` passes on the modified file
- Note: `npm run build` and `ng test` fail repo-wide due to a pre-existing missing `Common-UI` peer dependency, not related to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched browser alerts to in-app error notifications for language switching for a more consistent UI.
  * Removed debug logging from language change operations.

* **Bug Fixes**
  * Improved handling when language data or translations are missing, preventing errors and falling back to default English messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->