### PR TITLE
fix(auth-guard): remove memory-leaking subscription in canActivate

### DIFF
--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router, ActivatedRoute } from '@angular/router';
+import { CanActivate, Router } from '@angular/router';
 import { tap } from 'rxjs';
 import { AuthService } from './auth.service';
 
@@ -7,8 +7,7 @@ import { AuthService } from './auth.service';
 export class AuthGuard implements CanActivate {
   constructor(
     private auth: AuthService,
-    private router: Router,
-    private route: ActivatedRoute
+    private router: Router
   ) {}
 
   canActivate(route: any, state: any) {

--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,22 +1,17 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRoute } from '@angular/router';
 import { tap } from 'rxjs';
-import { HttpServiceService } from '../../core/services/http-service.service';
 import { AuthService } from './auth.service';
+
 @Injectable()
 export class AuthGuard implements CanActivate {
-  current_language_set: any;
   constructor(
     private auth: AuthService,
     private router: Router,
-    private route: ActivatedRoute,
-    private http_service: HttpServiceService
+    private route: ActivatedRoute
   ) {}
 
   canActivate(route: any, state: any) {
-    this.http_service.currentLangugae$.subscribe(
-      response => (this.current_language_set = response)
-    );
     return this.auth.validateSessionKey().pipe(
       tap((res: any) => {
         if (!(res && res.statusCode === 200 && res.data)) {


### PR DESCRIPTION
## Problem

Fixes #138 (reported in PSMRI/AMRIT).

`AuthGuard.canActivate()` subscribes to `http_service.currentLangugae$` on every route activation with no cleanup mechanism:

```ts
canActivate(route: any, state: any) {
  this.http_service.currentLangugae$.subscribe(
    response => (this.current_language_set = response)
  );
  // ...
}
```

Because `AuthGuard` is a singleton and `currentLangugae$` is a `BehaviorSubject` that never completes, each navigation to any of the 7 guarded routes (`/service`, `/servicePoint`, `/registrar`, `/nurse-doctor`, `/lab`, `/pharmacist`, `/datasync`) adds a subscription that is never released. Subscriber count grows indefinitely with every navigation.

Additionally, the subscribed value `current_language_set` is only assigned — it is never read anywhere in the class — so the subscription has no functional effect at all.

## Fix

Remove the subscription, the `current_language_set` property, and the now-unused `HttpServiceService` import and constructor injection. The guard's actual logic (`auth.validateSessionKey()`) is unchanged.

```ts
canActivate(route: any, state: any) {
  return this.auth.validateSessionKey().pipe(
    tap((res: any) => {
      if (!(res && res.statusCode === 200 && res.data)) {
        this.router.navigate(['/login']);
      }
    })
  );
}
```

## Impact

- Eliminates unbounded memory growth on protected-route navigation
- No behaviour change — the removed code had no observable effect