### PR TITLE
fix(login): rename AfterViewInit hook to ngAfterViewInit and fix rxjs internal import in interceptor

### DIFF
--- a/src/app/app-modules/core/services/http-interceptor.service.ts
+++ b/src/app/app-modules/core/services/http-interceptor.service.ts
@@ -10,9 +10,8 @@ import {
   HttpHeaders,
 } from '@angular/common/http';
 import { catchError, tap, finalize } from 'rxjs/operators';
-import { Observable, of, Subject, EMPTY } from 'rxjs';
+import { Observable, of, EMPTY, throwError } from 'rxjs';
 import { Router } from '@angular/router';
-import { throwError } from 'rxjs/internal/observable/throwError';
 import { SpinnerService } from './spinner.service';
 import { ConfirmationService } from './confirmation.service';
 import { environment } from 'src/environments/environment';

--- a/src/app/app-modules/login/login.component.ts
+++ b/src/app/app-modules/login/login.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import * as CryptoJS from 'crypto-js';
@@ -41,7 +41,7 @@ import { AmritTrackingService } from 'Common-UI/src/tracking';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css'],
 })
-export class LoginComponent implements OnInit {
+export class LoginComponent implements OnInit, AfterViewInit {
   @ViewChild('captchaCmp') captchaCmp: CaptchaComponent | undefined;
   dynamictype = 'password';
   encryptedVar: any;
@@ -88,7 +88,7 @@ export class LoginComponent implements OnInit {
       sessionStorage.clear();
     }
   }
-  public AfterViewInit(): void {
+  ngAfterViewInit(): void {
     this.elementRef.nativeElement.focus();
   }
 

--- a/src/app/app-modules/login/login.component.ts
+++ b/src/app/app-modules/login/login.component.ts
@@ -20,7 +20,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  AfterViewInit,
+  ViewChild,
+  ElementRef,
+} from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import * as CryptoJS from 'crypto-js';


### PR DESCRIPTION
## Summary

Two bugs across `login.component.ts` and `http-interceptor.service.ts`.

---

### Bug 1 — Misnamed Angular lifecycle hook in `login.component.ts`

```typescript
// Before — a plain public method, never called by Angular
export class LoginComponent implements OnInit {
  public AfterViewInit(): void {
    this.elementRef.nativeElement.focus();
  }
}

// After — correctly named lifecycle hook, called by Angular after view init
export class LoginComponent implements OnInit, AfterViewInit {
  ngAfterViewInit(): void {
    this.elementRef.nativeElement.focus();
  }
}
```

Angular calls lifecycle hooks by their conventional `ng`-prefixed name. The method was named `AfterViewInit` (capital A, no `ng` prefix), making it an ordinary public method that Angular never invokes. As a result, the `@ViewChild('focus')` element was never focused after the view initialised. Fixed by:
1. Adding `AfterViewInit` to the `@angular/core` import
2. Adding `AfterViewInit` to the `implements` clause
3. Renaming the method to `ngAfterViewInit`

---

### Bug 2 — `throwError` imported from RxJS internal path in `http-interceptor.service.ts`

```typescript
// Before — private internal API, not guaranteed stable across RxJS minor versions
import { Observable, of, Subject, EMPTY } from 'rxjs';
import { throwError } from 'rxjs/internal/observable/throwError';

// After — public stable API; Subject removed (unused)
import { Observable, of, EMPTY, throwError } from 'rxjs';
```

`rxjs/internal/*` is not part of RxJS's public API contract. Importing from it can silently break on any minor or patch update. `throwError` has been exported from the top-level `'rxjs'` package since RxJS 6. `Subject` was also imported but never referenced anywhere in the file, so it has been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login form now automatically receives focus when the page loads for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->