### PR TITLE
fix(error-handler): use console.error and remove re-throw to prevent zone error loop

### DIFF
--- a/src/app/app-modules/core/services/global-error-handler.service.ts
+++ b/src/app/app-modules/core/services/global-error-handler.service.ts
@@ -25,7 +25,11 @@ import { ErrorHandler, Injectable } from '@angular/core';
 @Injectable()
 export class GlobalErrorHandler implements ErrorHandler {
   handleError(error: Error) {
-    console.log(error);
-    throw error;
+    // Use console.error so the browser DevTools error panel captures it and
+    // it is distinguishable from informational logs.
+    // Do NOT re-throw here: Angular's ErrorHandler runs inside NgZone and
+    // re-throwing causes the zone to invoke handleError again, creating an
+    // infinite loop that freezes the application.
+    console.error(error);
   }
 }


### PR DESCRIPTION
## Summary

Two bugs in `src/app/app-modules/core/services/global-error-handler.service.ts`.

---

### Bug 1 — Wrong log level: `console.log` instead of `console.error`

```typescript
// Before
console.log(error);

// After
console.error(error);
```

`GlobalErrorHandler` is Angular's last-resort error sink. Using `console.log` means errors are indistinguishable from informational messages and are invisible in browser DevTools when the "Errors" filter is active. `console.error` correctly marks the entry as an error, triggers the red badge in DevTools, and is picked up by external monitoring tools (Sentry, Datadog, etc.).

---

### Bug 2 — Re-throwing inside `ErrorHandler.handleError` causes an infinite loop

```typescript
// Before
handleError(error: Error) {
  console.log(error);
  throw error;      // ← re-enters NgZone error handling → calls handleError again
}

// After
handleError(error: Error) {
  console.error(error);
  // No re-throw: ErrorHandler is the terminal handler; re-throwing loops back
  // into Angular's zone which invokes handleError a second time, eventually
  // freezing the application with a call-stack overflow.
}
```

Angular's `ErrorHandler.handleError` is called by NgZone when an unhandled error escapes. Re-throwing inside the handler causes NgZone to catch the error again and call `handleError` recursively, which can freeze the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging and improved global error handling to prevent uncontrolled error propagation, resulting in more stable application operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->