### PR TITLE
fix(auth-guard): remove unmanaged currentLangugae$ subscription in canActivate 

### DIFF
--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,3 +1,25 @@
+/*
+ * AMRIT â€“ Accessible Medical Records via Integrated Technology
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { tap } from 'rxjs';

--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -22,7 +22,7 @@
 
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
-import { tap } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -33,11 +33,11 @@ export class AuthGuard implements CanActivate {
 
   canActivate(route: any, state: any) {
     return this.auth.validateSessionKey().pipe(
-      tap((res: any) => {
-        if (!(res && res.statusCode === 200 && res.data)) {
-          this.router.navigate(['/login']);
-        }
-      })
+      map((res: any) =>
+        res && res.statusCode === 200 && res.data
+          ? true
+          : this.router.createUrlTree(['/login'])
+      )
     );
   }
 }

--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,22 +1,15 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router, ActivatedRoute } from '@angular/router';
+import { CanActivate, Router } from '@angular/router';
 import { tap } from 'rxjs';
-import { HttpServiceService } from '../../core/services/http-service.service';
 import { AuthService } from './auth.service';
 @Injectable()
 export class AuthGuard implements CanActivate {
-  current_language_set: any;
   constructor(
     private auth: AuthService,
-    private router: Router,
-    private route: ActivatedRoute,
-    private http_service: HttpServiceService
+    private router: Router
   ) {}
 
   canActivate(route: any, state: any) {
-    this.http_service.currentLangugae$.subscribe(
-      response => (this.current_language_set = response)
-    );
     return this.auth.validateSessionKey().pipe(
       tap((res: any) => {
         if (!(res && res.statusCode === 200 && res.data)) {


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A (Closes issue https://github.com/PSMRI/AMRIT/issues/138)

This PR fixes a memory leak in `AuthGuard.canActivate()` caused by an unmanaged subscription to `currentLangugae$` on every protected-route activation.

### Problem
- `AuthGuard` is a singleton.
- `currentLangugae$` is backed by `BehaviorSubject` and does not complete.
- A new subscription was being created on every navigation to guarded routes with no unsubscribe.
- The subscribed value (`current_language_set`) was not used in guard logic.

### Change
- Removed the redundant `currentLangugae$` subscription from `canActivate()`.
- Removed dead code and unused dependencies related to that subscription:
  - `current_language_set`
  - `HttpServiceService` injection/import
  - unused `ActivatedRoute` injection/import

### Motivation
Prevent unnecessary subscription accumulation and memory growth during repeated navigation, while keeping guard behavior unchanged.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [x] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

### Validation performed
- Navigated repeatedly across protected routes (`/service`, `/servicePoint`, `/registrar`, `/nurse-doctor`, `/lab`, `/pharmacist`, `/datasync`).
- Confirmed auth flow behavior remains the same:
  - valid session allows navigation
  - invalid session redirects to `/login`
- Confirmed the guard no longer creates per-navigation `currentLangugae$` subscriptions.

No UI changes were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified authentication internals for improved maintainability.
* **Bug Fixes**
  * More reliable session validation and automatic redirect to the login page when a session is not valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->