### PR TITLE
build: point MMU-UI at Common-UI v2

### DIFF
--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -29,7 +29,7 @@ import { HttpServiceService } from '../../services/http-service.service';
 import { IotService } from '../../services/iot.service';
 import { IotBluetoothComponent } from '../iot-bluetooth/iot-bluetooth.component';
 import { ShowCommitAndVersionDetailsComponent } from '../show-commit-and-version-details/show-commit-and-version-details.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-header',

--- a/src/app/app-modules/core/components/beneficiary-details/beneficiary-details.component.ts
+++ b/src/app/app-modules/core/components/beneficiary-details/beneficiary-details.component.ts
@@ -25,7 +25,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { BeneficiaryDetailsService } from '../../services/beneficiary-details.service';
 import { HttpServiceService } from '../../services/http-service.service';
 import { SetLanguageComponent } from '../set-language.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-beneficiary-details',

--- a/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
+++ b/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
@@ -40,7 +40,7 @@ import html2canvas from 'html2canvas';
 import { WebcamImage, WebcamInitError } from 'ngx-webcam';
 import { Observable } from 'rxjs';
 import { saveAs } from 'file-saver';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 interface Mark {
   xCord: any;

--- a/src/app/app-modules/core/components/data-sync-login/data-sync-login.component.ts
+++ b/src/app/app-modules/core/components/data-sync-login/data-sync-login.component.ts
@@ -30,7 +30,7 @@ import { SetLanguageComponent } from '../set-language.component';
 import { ConfirmationService } from '../../services';
 import { HttpServiceService } from '../../services/http-service.service';
 import { DataSyncService } from '../../../data-sync/shared/service/data-sync.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-data-sync-login',

--- a/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
+++ b/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
@@ -31,7 +31,7 @@ import { HttpServiceService } from '../../services/http-service.service';
 import { IotService } from '../../services/iot.service';
 import { SetLanguageComponent } from '../set-language.component';
 import { CalibrationComponent } from '../calibration/calibration.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-iotcomponent',

--- a/src/app/app-modules/core/directives/confirmatory-diagnosis.directive.ts
+++ b/src/app/app-modules/core/directives/confirmatory-diagnosis.directive.ts
@@ -39,7 +39,7 @@ import { SetLanguageComponent } from '../components/set-language.component';
 import { HttpServiceService } from '../services/http-service.service';
 import { MatDialog } from '@angular/material/dialog';
 import { ProvisionalSearchComponent } from '../components/provisional-search/provisional-search.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Directive({
   selector: '[appConfirmatoryDiagnosis]',
   standalone: false,

--- a/src/app/app-modules/core/directives/open-modal.directive.ts
+++ b/src/app/app-modules/core/directives/open-modal.directive.ts
@@ -39,7 +39,7 @@ import { GeneralUtils } from '../../nurse-doctor/shared/utility/general-utility'
 import { SetLanguageComponent } from '../components/set-language.component';
 import { HttpServiceService } from '../services/http-service.service';
 import { MatDialog } from '@angular/material/dialog';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Directive({
   selector: '[appOpenModal]',

--- a/src/app/app-modules/core/services/http-interceptor.service.ts
+++ b/src/app/app-modules/core/services/http-interceptor.service.ts
@@ -16,7 +16,7 @@ import { throwError } from 'rxjs/internal/observable/throwError';
 import { SpinnerService } from './spinner.service';
 import { ConfirmationService } from './confirmation.service';
 import { environment } from 'src/environments/environment';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { CookieService } from 'ngx-cookie-service';
 
 @Injectable({

--- a/src/app/app-modules/core/services/inventory.service.ts
+++ b/src/app/app-modules/core/services/inventory.service.ts
@@ -24,7 +24,7 @@ import { Injectable, Inject } from '@angular/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { environment } from 'src/environments/environment';
 import { DOCUMENT } from '@angular/common';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Injectable()
 export class InventoryService {
   inventoryUrl: any;

--- a/src/app/app-modules/data-sync/master-download/master-download.component.ts
+++ b/src/app/app-modules/data-sync/master-download/master-download.component.ts
@@ -25,7 +25,7 @@ import { Router } from '@angular/router';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { DataSyncService } from './../shared/service/data-sync.service';
 import { MatDialogRef } from '@angular/material/dialog';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-master-download',

--- a/src/app/app-modules/data-sync/shared/service/data-sync.service.ts
+++ b/src/app/app-modules/data-sync/shared/service/data-sync.service.ts
@@ -22,7 +22,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { environment } from 'src/environments/environment';
 
 @Injectable()

--- a/src/app/app-modules/data-sync/workarea/workarea.component.ts
+++ b/src/app/app-modules/data-sync/workarea/workarea.component.ts
@@ -35,7 +35,7 @@ import { CanComponentDeactivate } from '../../core/services/can-deactivate-guard
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-workarea',

--- a/src/app/app-modules/lab/shared/services/lab.service.ts
+++ b/src/app/app-modules/lab/shared/services/lab.service.ts
@@ -22,7 +22,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { environment } from 'src/environments/environment';
 @Injectable()
 export class LabService {

--- a/src/app/app-modules/lab/workarea/workarea.canactivate.service.ts
+++ b/src/app/app-modules/lab/workarea/workarea.canactivate.service.ts
@@ -27,7 +27,7 @@ import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
 } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Injectable()
 export class WorkareaCanActivate implements CanActivate {

--- a/src/app/app-modules/lab/workarea/workarea.component.ts
+++ b/src/app/app-modules/lab/workarea/workarea.component.ts
@@ -39,7 +39,7 @@ import { Observable, of } from 'rxjs';
 import { IotcomponentComponent } from '../../core/components/iotcomponent/iotcomponent.component';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-workarea',

--- a/src/app/app-modules/lab/worklist/worklist.component.ts
+++ b/src/app/app-modules/lab/worklist/worklist.component.ts
@@ -38,7 +38,7 @@ import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-worklist',

--- a/src/app/app-modules/login/login.component.ts
+++ b/src/app/app-modules/login/login.component.ts
@@ -37,10 +37,10 @@ import {
 import { FormBuilder, Validators } from '@angular/forms';
 import { DataSyncLoginComponent } from '../core/components/data-sync-login/data-sync-login.component';
 import { MasterDownloadComponent } from '../data-sync/master-download/master-download.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { environment } from 'src/environments/environment';
 import { CaptchaComponent } from '../captcha/captcha.component';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-login-cmp',

--- a/src/app/app-modules/nurse-doctor/anc/anc-immunization/anc-immunization.component.ts
+++ b/src/app/app-modules/nurse-doctor/anc/anc-immunization/anc-immunization.component.ts
@@ -42,7 +42,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-anc-immunization',

--- a/src/app/app-modules/nurse-doctor/anc/anc.component.ts
+++ b/src/app/app-modules/nurse-doctor/anc/anc.component.ts
@@ -34,7 +34,7 @@ import { ConfirmationService } from '../../core/services/confirmation.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { BeneficiaryDetailsService } from '../../core/services';
 import { HttpServiceService } from '../../core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-nurse-anc',
   templateUrl: './anc.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/beneficiary-platform-history/beneficiary-platform-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/beneficiary-platform-history/beneficiary-platform-history.component.ts
@@ -31,7 +31,7 @@ import { BeneficiaryMctsCallHistoryComponent } from '../beneficiary-mcts-call-hi
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { CaseSheetComponent } from '../../case-sheet/case-sheet.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { Router } from '@angular/router';
 @Component({
   selector: 'app-beneficiary-platform-history',

--- a/src/app/app-modules/nurse-doctor/case-record/cancer-case-record/cancer-case-record.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/cancer-case-record/cancer-case-record.component.ts
@@ -38,7 +38,7 @@ import { CameraService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-cancer-case-record',
   templateUrl: './cancer-case-record.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/anc-diagnosis/anc-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/anc-diagnosis/anc-diagnosis.component.ts
@@ -35,7 +35,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-anc-diagnosis',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/covid-diagnosis/covid-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/covid-diagnosis/covid-diagnosis.component.ts
@@ -28,7 +28,7 @@ import { DoctorService } from '../../../../shared/services';
 import { GeneralUtils } from '../../../../shared/utility';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-covid-diagnosis',
   templateUrl: './covid-diagnosis.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/general-opd-diagnosis/general-opd-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/general-opd-diagnosis/general-opd-diagnosis.component.ts
@@ -32,7 +32,7 @@ import { DoctorService, MasterdataService } from '../../../../shared/services';
 import { GeneralUtils } from '../../../../shared/utility/general-utility';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-general-opd-diagnosis',
   templateUrl: './general-opd-diagnosis.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-care-diagnosis/ncd-care-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-care-diagnosis/ncd-care-diagnosis.component.ts
@@ -33,7 +33,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { GeneralUtils } from 'src/app/app-modules/nurse-doctor/shared/utility';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-ncd-care-diagnosis',
   templateUrl: './ncd-care-diagnosis.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-screening-diagnosis/ncd-screening-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-screening-diagnosis/ncd-screening-diagnosis.component.ts
@@ -27,7 +27,7 @@ import {
   FormArray,
   AbstractControl,
 } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/pnc-diagnosis/pnc-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/pnc-diagnosis/pnc-diagnosis.component.ts
@@ -49,7 +49,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-pnc-diagnosis',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/doctor-investigations/doctor-investigations.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/doctor-investigations/doctor-investigations.component.ts
@@ -33,7 +33,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { environment } from 'src/environments/environment';
 import { IdrsscoreService } from '../../../shared/services/idrsscore.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-doctor-investigations',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/findings/findings.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/findings/findings.component.ts
@@ -51,8 +51,8 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { environment } from 'src/environments/environment';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-findings',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/prescription/prescription.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/prescription/prescription.component.ts
@@ -42,8 +42,8 @@ import { ConfirmationService } from '../../../../core/services/confirmation.serv
 import { PageEvent } from '@angular/material/paginator';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 interface prescribe {
   id: any;

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/previous-significiant-findings/previous-significiant-findings.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/previous-significiant-findings/previous-significiant-findings.component.ts
@@ -32,7 +32,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-previous-significiant-findings',
   templateUrl: './previous-significiant-findings.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/previous-visit-details/previous-visit-details.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/previous-visit-details/previous-visit-details.component.ts
@@ -26,7 +26,7 @@ import { CameraService } from '../../../../core/services/camera.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { Router } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-previous-visit-details',
   templateUrl: './previous-visit-details.component.html',

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/test-and-radiology/test-and-radiology.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/test-and-radiology/test-and-radiology.component.ts
@@ -39,7 +39,7 @@ import { ViewRadiologyUploadedFilesComponent } from 'src/app/app-modules/core/co
 import { LabService } from 'src/app/app-modules/lab/shared/services';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-test-and-radiology',
   templateUrl: './test-and-radiology.component.html',

--- a/src/app/app-modules/nurse-doctor/case-sheet/cancer-case-sheet/cancer-case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/cancer-case-sheet/cancer-case-sheet.component.ts
@@ -29,7 +29,7 @@ import { PrintPageSelectComponent } from '../../print-page-select/print-page-sel
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-cancer-case-sheet',

--- a/src/app/app-modules/nurse-doctor/case-sheet/cancer-case-sheet/cancer-doctor-diagnosis-case-sheet/cancer-doctor-diagnosis-case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/cancer-case-sheet/cancer-doctor-diagnosis-case-sheet/cancer-doctor-diagnosis-case-sheet.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, OnChanges, DoCheck } from '@angular/core';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MasterdataService } from '../../../shared/services';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-cancer-doctor-diagnosis-case-sheet',

--- a/src/app/app-modules/nurse-doctor/case-sheet/case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/case-sheet.component.ts
@@ -25,7 +25,7 @@ import { ActivatedRoute } from '@angular/router';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-case-sheet',

--- a/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/doctor-diagnosis-case-sheet/doctor-diagnosis-case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/doctor-diagnosis-case-sheet/doctor-diagnosis-case-sheet.component.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../shared/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import * as moment from 'moment';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { get } from 'jquery';
 import { map, Observable } from 'rxjs';
 

--- a/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/examination-case-sheet/examination-case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/examination-case-sheet/examination-case-sheet.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, OnChanges, DoCheck } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-examination-case-sheet',

--- a/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/general-case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/general-case-sheet.component.ts
@@ -31,7 +31,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { PrintPageSelectComponent } from '../../print-page-select/print-page-select.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-case-sheet',

--- a/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/history-case-sheet/history-case-sheet.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/history-case-sheet/history-case-sheet.component.ts
@@ -26,7 +26,7 @@ import * as moment from 'moment';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { DoctorService } from '../../../shared/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-history-case-sheet',

--- a/src/app/app-modules/nurse-doctor/case-sheet/prescribe-tm-medicine/prescribe-tm-medicine.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-sheet/prescribe-tm-medicine/prescribe-tm-medicine.component.ts
@@ -38,7 +38,7 @@ import { PageEvent } from '@angular/material/paginator';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 interface prescribe {
   id: any;
   drugID: any;

--- a/src/app/app-modules/nurse-doctor/doctor-worklist/doctor-worklist.component.ts
+++ b/src/app/app-modules/nurse-doctor/doctor-worklist/doctor-worklist.component.ts
@@ -39,7 +39,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-doctor-worklist',
   templateUrl: './doctor-worklist.component.html',

--- a/src/app/app-modules/nurse-doctor/examination/cancer-examination/cancer-examination.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/cancer-examination/cancer-examination.component.ts
@@ -36,7 +36,7 @@ import {
 } from '../../../core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-cancer-examination',
   templateUrl: './cancer-examination.component.html',

--- a/src/app/app-modules/nurse-doctor/examination/cancer-examination/gynecological-examination/gynecological-examination.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/cancer-examination/gynecological-examination/gynecological-examination.component.ts
@@ -36,7 +36,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { DoctorService, NurseService } from '../../../shared/services';
 import { LabService } from 'src/app/app-modules/lab/shared/services';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { ViewRadiologyUploadedFilesComponent } from 'src/app/app-modules/core/components/view-radiology-uploaded-files/view-radiology-uploaded-files.component';
 import { MatDialog } from '@angular/material/dialog';
 

--- a/src/app/app-modules/nurse-doctor/examination/cancer-examination/signs-and-symptoms/signs-and-symptoms.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/cancer-examination/signs-and-symptoms/signs-and-symptoms.component.ts
@@ -40,7 +40,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-doctor-signs-and-symptoms',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/general-examination/general-examination.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/general-examination/general-examination.component.ts
@@ -22,10 +22,10 @@
 
 import { Component, OnInit, Input, DoCheck, OnChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-general-examination',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/general-opd-examination.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/general-opd-examination.component.ts
@@ -33,7 +33,7 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { DoctorService } from '../../shared/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-general-opd-examination',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/head-to-toe-examination/head-to-toe-examination.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/head-to-toe-examination/head-to-toe-examination.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, DoCheck } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-head-to-toe-examination',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/cardio-vascular-system/cardio-vascular-system.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/cardio-vascular-system/cardio-vascular-system.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, DoCheck } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-cardio-vascular-system',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/central-nervous-system/central-nervous-system.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/central-nervous-system/central-nervous-system.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, DoCheck } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-central-nervous-system',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/gastro-intestinal-system/gastro-intestinal-system.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/gastro-intestinal-system/gastro-intestinal-system.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, DoCheck } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-gastro-intestinal-system',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/genito-urinary-system/genito-urinary-system.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/genito-urinary-system/genito-urinary-system.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, DoCheck } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-genito-urinary-system',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/musculoskeletal-system/musculoskeletal-system.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/musculoskeletal-system/musculoskeletal-system.component.ts
@@ -25,7 +25,7 @@ import { MasterdataService } from '../../../../shared/services';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-musculoskeletal-system',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/respiratory-system/respiratory-system.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/respiratory-system/respiratory-system.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, DoCheck } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-respiratory-system',

--- a/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/systemic-examination.component.ts
+++ b/src/app/app-modules/nurse-doctor/examination/general-opd-examination/systemic-examination/systemic-examination.component.ts
@@ -25,8 +25,8 @@ import { GeneralUtils } from '../../../shared/utility/general-utility';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-systemic-examination',

--- a/src/app/app-modules/nurse-doctor/history/cancer-history/cancer-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/cancer-history/cancer-history.component.ts
@@ -35,7 +35,7 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { DoctorService } from '../../shared/services/doctor.service';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-cancer-history',

--- a/src/app/app-modules/nurse-doctor/history/cancer-history/family-disease-history/family-disease-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/cancer-history/family-disease-history/family-disease-history.component.ts
@@ -48,7 +48,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatDialog } from '@angular/material/dialog';
 import { PreviousDetailsComponent } from 'src/app/app-modules/core/components/previous-details/previous-details.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-cancer-family-disease-history',

--- a/src/app/app-modules/nurse-doctor/history/cancer-history/obstetric-history/obstetric-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/cancer-history/obstetric-history/obstetric-history.component.ts
@@ -40,7 +40,7 @@ import { PreviousDetailsComponent } from '../../../../core/components/previous-d
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatDialog } from '@angular/material/dialog';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-cancer-obstetric-history',

--- a/src/app/app-modules/nurse-doctor/history/cancer-history/personal-history/personal-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/cancer-history/personal-history/personal-history.component.ts
@@ -37,7 +37,7 @@ import { PreviousDetailsComponent } from '../../../../core/components/previous-d
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatDialog } from '@angular/material/dialog';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-cancer-personal-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/comorbidity-concurrent-conditions/comorbidity-concurrent-conditions.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/comorbidity-concurrent-conditions/comorbidity-concurrent-conditions.component.ts
@@ -40,7 +40,7 @@ import { BeneficiaryDetailsService } from '../../../../core/services/beneficiary
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-comorbidity-concurrent-conditions',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/development-history/development-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/development-history/development-history.component.ts
@@ -32,7 +32,7 @@ import { ConfirmationService } from '../../../../core/services/confirmation.serv
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-development-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/family-history-ncdscreening/family-history-ncdscreening.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/family-history-ncdscreening/family-history-ncdscreening.component.ts
@@ -41,7 +41,7 @@ import {
   MasterdataService,
 } from '../../../shared/services';
 import { IdrsscoreService } from '../../../shared/services/idrsscore.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-family-history-ncdscreening',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/family-history/family-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/family-history/family-history.component.ts
@@ -38,7 +38,7 @@ import { ConfirmationService } from '../../../../core/services/confirmation.serv
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-family-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/feeding-history/feeding-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/feeding-history/feeding-history.component.ts
@@ -34,7 +34,7 @@ import { ConfirmationService } from '../../../../core/services/confirmation.serv
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-feeding-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/general-opd-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/general-opd-history.component.ts
@@ -34,7 +34,7 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { DoctorService } from '../../shared/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-general-opd-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/immunization-history/immunization-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/immunization-history/immunization-history.component.ts
@@ -27,7 +27,7 @@ import { MasterdataService, DoctorService } from '../../../shared/services';
 import { BeneficiaryDetailsService } from '../../../../core/services/beneficiary-details.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-immunization-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/medication-history/medication-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/medication-history/medication-history.component.ts
@@ -47,7 +47,7 @@ import { BeneficiaryDetailsService } from '../../../../core/services/beneficiary
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-medication-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/menstrual-history/menstrual-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/menstrual-history/menstrual-history.component.ts
@@ -42,7 +42,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-menstrual-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/other-vaccines/other-vaccines.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/other-vaccines/other-vaccines.component.ts
@@ -40,7 +40,7 @@ import { BeneficiaryDetailsService } from '../../../../core/services/beneficiary
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-other-vaccines',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/past-history/past-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/past-history/past-history.component.ts
@@ -46,8 +46,8 @@ import { ValidationUtils } from '../../../shared/utility/validation-utility';
 import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-general-past-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/past-obsteric-history/past-obsteric-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/past-obsteric-history/past-obsteric-history.component.ts
@@ -46,7 +46,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { MatDialog } from '@angular/material/dialog';
 import { PreviousDetailsComponent } from 'src/app/app-modules/core/components/previous-details/previous-details.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-past-obsteric-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/perinatal-history/perinatal-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/perinatal-history/perinatal-history.component.ts
@@ -32,7 +32,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { PreviousDetailsComponent } from 'src/app/app-modules/core/components/previous-details/previous-details.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-general-perinatal-history',
   templateUrl: './perinatal-history.component.html',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/personal-history/personal-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/personal-history/personal-history.component.ts
@@ -49,7 +49,7 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { PreviousDetailsComponent } from 'src/app/app-modules/core/components/previous-details/previous-details.component';
 import { AllergenSearchComponent } from 'src/app/app-modules/core/components/allergen-search/allergen-search.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-personal-history',

--- a/src/app/app-modules/nurse-doctor/history/general-opd-history/physical-activity-history/physical-activity-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/general-opd-history/physical-activity-history/physical-activity-history.component.ts
@@ -36,7 +36,7 @@ import {
 import { IdrsscoreService } from '../../../shared/services/idrsscore.service';
 import { MatDialog } from '@angular/material/dialog';
 import { PreviousDetailsComponent } from 'src/app/app-modules/core/components/previous-details/previous-details.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-physical-activity-history',
   templateUrl: './physical-activity-history.component.html',

--- a/src/app/app-modules/nurse-doctor/history/history.component.ts
+++ b/src/app/app-modules/nurse-doctor/history/history.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit, Input, OnChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { DoctorService } from '../shared/services/doctor.service';
 import { ActivatedRoute } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-history',

--- a/src/app/app-modules/nurse-doctor/idrs/idrs.component.ts
+++ b/src/app/app-modules/nurse-doctor/idrs/idrs.component.ts
@@ -50,7 +50,7 @@ import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { PreviousDetailsComponent } from '../../core/components/previous-details/previous-details.component';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-idrs',

--- a/src/app/app-modules/nurse-doctor/ncd-screening/ncd-screening.component.ts
+++ b/src/app/app-modules/nurse-doctor/ncd-screening/ncd-screening.component.ts
@@ -53,7 +53,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-ncd-screening',

--- a/src/app/app-modules/nurse-doctor/nurse-worklist-tabs/nurse-reffered-worklist/nurse-reffered-worklist.component.ts
+++ b/src/app/app-modules/nurse-doctor/nurse-worklist-tabs/nurse-reffered-worklist/nurse-reffered-worklist.component.ts
@@ -33,7 +33,7 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import * as moment from 'moment';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-reffered-worklist',

--- a/src/app/app-modules/nurse-doctor/nurse-worklist/nurse-worklist.component.ts
+++ b/src/app/app-modules/nurse-doctor/nurse-worklist/nurse-worklist.component.ts
@@ -37,7 +37,7 @@ import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-worklist',

--- a/src/app/app-modules/nurse-doctor/oncologist-worklist/oncologist-worklist.component.ts
+++ b/src/app/app-modules/nurse-doctor/oncologist-worklist/oncologist-worklist.component.ts
@@ -32,7 +32,7 @@ import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-oncologist-worklist',

--- a/src/app/app-modules/nurse-doctor/pnc/pnc.component.ts
+++ b/src/app/app-modules/nurse-doctor/pnc/pnc.component.ts
@@ -47,7 +47,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-nurse-pnc',

--- a/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.ts
+++ b/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.ts
@@ -60,7 +60,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { IotcomponentComponent } from '../../core/components/iotcomponent/iotcomponent.component';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 interface prescribe {
   id: any;

--- a/src/app/app-modules/nurse-doctor/radiologist-worklist/radiologist-worklist.component.ts
+++ b/src/app/app-modules/nurse-doctor/radiologist-worklist/radiologist-worklist.component.ts
@@ -38,7 +38,7 @@ import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-radiologist-worklist',

--- a/src/app/app-modules/nurse-doctor/refer/cancer-refer/cancer-refer.component.ts
+++ b/src/app/app-modules/nurse-doctor/refer/cancer-refer/cancer-refer.component.ts
@@ -34,7 +34,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-cancer-refer',

--- a/src/app/app-modules/nurse-doctor/refer/general-refer/general-refer.component.ts
+++ b/src/app/app-modules/nurse-doctor/refer/general-refer/general-refer.component.ts
@@ -44,7 +44,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-general-refer',

--- a/src/app/app-modules/nurse-doctor/reports/reports.component.ts
+++ b/src/app/app-modules/nurse-doctor/reports/reports.component.ts
@@ -37,8 +37,8 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 declare global {
   interface Navigator {

--- a/src/app/app-modules/nurse-doctor/shared/services/doctor.service.ts
+++ b/src/app/app-modules/nurse-doctor/shared/services/doctor.service.ts
@@ -23,7 +23,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FormGroup, FormArray, FormControl } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { BehaviorSubject, Observable, map } from 'rxjs';
 import { environment } from 'src/environments/environment';
 

--- a/src/app/app-modules/nurse-doctor/shared/services/masterdata.service.ts
+++ b/src/app/app-modules/nurse-doctor/shared/services/masterdata.service.ts
@@ -22,7 +22,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 

--- a/src/app/app-modules/nurse-doctor/shared/services/nurse.service.ts
+++ b/src/app/app-modules/nurse-doctor/shared/services/nurse.service.ts
@@ -27,7 +27,7 @@ import { shareReplay } from 'rxjs/operators';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Injectable()
 export class NurseService {

--- a/src/app/app-modules/nurse-doctor/shared/utility/cancer-utility.ts
+++ b/src/app/app-modules/nurse-doctor/shared/utility/cancer-utility.ts
@@ -21,7 +21,7 @@
  */
 
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 export class CancerUtils {
   // serviceLineDetails: any = null;

--- a/src/app/app-modules/nurse-doctor/shared/utility/general-utility.ts
+++ b/src/app/app-modules/nurse-doctor/shared/utility/general-utility.ts
@@ -21,7 +21,7 @@
  */
 
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 export class GeneralUtils {
   constructor(

--- a/src/app/app-modules/nurse-doctor/shared/utility/ncd-screening-utility.ts
+++ b/src/app/app-modules/nurse-doctor/shared/utility/ncd-screening-utility.ts
@@ -21,7 +21,7 @@
  */
 
 import { FormBuilder, FormGroup, Validators, FormArray } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 export class NCDScreeningUtils {
   constructor(

--- a/src/app/app-modules/nurse-doctor/shared/utility/quick-consult-utility.ts
+++ b/src/app/app-modules/nurse-doctor/shared/utility/quick-consult-utility.ts
@@ -21,7 +21,7 @@
  */
 
 import { FormBuilder, FormGroup, Validators, FormArray } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 export class QuickConsultUtils {
   constructor(

--- a/src/app/app-modules/nurse-doctor/shared/utility/visit-detail-utility.ts
+++ b/src/app/app-modules/nurse-doctor/shared/utility/visit-detail-utility.ts
@@ -21,7 +21,7 @@
  */
 
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 export class VisitDetailUtils {
   constructor(

--- a/src/app/app-modules/nurse-doctor/sms-notification/sms-notification.component.ts
+++ b/src/app/app-modules/nurse-doctor/sms-notification/sms-notification.component.ts
@@ -9,7 +9,7 @@ import { ConfirmationService } from '../../core/services';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { map, switchMap } from 'rxjs';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';

--- a/src/app/app-modules/nurse-doctor/tm-visit-details/tm-visit-details.component.ts
+++ b/src/app/app-modules/nurse-doctor/tm-visit-details/tm-visit-details.component.ts
@@ -26,7 +26,7 @@ import { Router } from '@angular/router';
 import { DoctorService, MasterdataService } from '../shared/services';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-tm-visit-details',

--- a/src/app/app-modules/nurse-doctor/tm-visit-details/tmcconfirmation/tmcconfirmation.component.ts
+++ b/src/app/app-modules/nurse-doctor/tm-visit-details/tmcconfirmation/tmcconfirmation.component.ts
@@ -38,7 +38,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { DataSyncLoginComponent } from 'src/app/app-modules/core/components/data-sync-login/data-sync-login.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-tmcconfirmation',

--- a/src/app/app-modules/nurse-doctor/visit-details/adherence/adherence.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/adherence/adherence.component.ts
@@ -25,7 +25,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { DoctorService } from '../../shared/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-patient-adherence',

--- a/src/app/app-modules/nurse-doctor/visit-details/chief-complaints/chief-complaints.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/chief-complaints/chief-complaints.component.ts
@@ -49,8 +49,8 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { environment } from 'src/environments/environment';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-patient-chief-complaints',

--- a/src/app/app-modules/nurse-doctor/visit-details/contact-history/contact-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/contact-history/contact-history.component.ts
@@ -38,7 +38,7 @@ import {
   MasterdataService,
   NurseService,
 } from '../../shared/services';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-contact-history',

--- a/src/app/app-modules/nurse-doctor/visit-details/covid-vaccination-status/covid-vaccination-status.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/covid-vaccination-status/covid-vaccination-status.component.ts
@@ -33,7 +33,7 @@ import {
   MasterdataService,
   DoctorService,
 } from '../../shared/services';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Component({
   selector: 'app-covid-vaccination-status',
   templateUrl: './covid-vaccination-status.component.html',

--- a/src/app/app-modules/nurse-doctor/visit-details/diseaseconfirmation/diseaseconfirmation.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/diseaseconfirmation/diseaseconfirmation.component.ts
@@ -30,7 +30,7 @@ import {
 } from '../../shared/services';
 import { IdrsscoreService } from '../../shared/services/idrsscore.service';
 import { VisitDetailUtils } from '../../shared/utility/visit-detail-utility';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-diseaseconfirmation',

--- a/src/app/app-modules/nurse-doctor/visit-details/investigations/investigations.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/investigations/investigations.component.ts
@@ -40,7 +40,7 @@ import {
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { environment } from 'src/environments/environment';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-patient-investigations',

--- a/src/app/app-modules/nurse-doctor/visit-details/symptoms/symptoms.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/symptoms/symptoms.component.ts
@@ -38,7 +38,7 @@ import {
 } from '../../shared/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-symptoms',

--- a/src/app/app-modules/nurse-doctor/visit-details/travel-history/travel-history.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/travel-history/travel-history.component.ts
@@ -36,7 +36,7 @@ import {
 } from '../../shared/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-travel-history',

--- a/src/app/app-modules/nurse-doctor/visit-details/upload-files/upload-files.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/upload-files/upload-files.component.ts
@@ -39,8 +39,8 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { MatDialog } from '@angular/material/dialog';
 import { LabService } from 'src/app/app-modules/lab/shared/services';
 import { ViewRadiologyUploadedFilesComponent } from 'src/app/app-modules/core/components/view-radiology-uploaded-files/view-radiology-uploaded-files.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-patient-upload-files',

--- a/src/app/app-modules/nurse-doctor/visit-details/visit-details.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/visit-details.component.ts
@@ -27,7 +27,7 @@ import { ConfirmationService } from '../../core/services/confirmation.service';
 import { DoctorService } from '../shared/services';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-visit-details',

--- a/src/app/app-modules/nurse-doctor/visit-details/visit-details/visit-details.component.ts
+++ b/src/app/app-modules/nurse-doctor/visit-details/visit-details/visit-details.component.ts
@@ -34,8 +34,8 @@ import { MasterdataService, DoctorService } from '../../shared/services';
 import { BeneficiaryDetailsService } from '../../../core/services/beneficiary-details.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-patient-visit-details',

--- a/src/app/app-modules/nurse-doctor/vitals/cancer-patient-vitals/cancer-patient-vitals.component.ts
+++ b/src/app/app-modules/nurse-doctor/vitals/cancer-patient-vitals/cancer-patient-vitals.component.ts
@@ -39,8 +39,8 @@ import { environment } from 'src/environments/environment';
 import { MatDialog } from '@angular/material/dialog';
 import { IotcomponentComponent } from 'src/app/app-modules/core/components/iotcomponent/iotcomponent.component';
 import { ActivatedRoute } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-cancer-patient-vitals',

--- a/src/app/app-modules/nurse-doctor/vitals/general-patient-vitals/general-patient-vitals.component.ts
+++ b/src/app/app-modules/nurse-doctor/vitals/general-patient-vitals/general-patient-vitals.component.ts
@@ -42,8 +42,8 @@ import { IdrsscoreService } from '../../shared/services/idrsscore.service';
 import { MatDialog } from '@angular/material/dialog';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-nurse-general-patient-vitals',

--- a/src/app/app-modules/nurse-doctor/workarea/workarea-can-activate.service.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea-can-activate.service.ts
@@ -27,7 +27,7 @@ import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
 } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Injectable()
 export class WorkareaCanActivate implements CanActivate {

--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
@@ -54,7 +54,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { environment } from 'src/environments/environment';
 import { CanComponentDeactivate } from '../../core/services/can-deactivate-guard.service';
 import { OpenPreviousVisitDetailsComponent } from '../../core/components/open-previous-visit-details/open-previous-visit-details.component';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { SmsNotificationComponent } from '../sms-notification/sms-notification.component';
 
 @Component({

--- a/src/app/app-modules/pharmacist/shared/services/pharmacist.service.ts
+++ b/src/app/app-modules/pharmacist/shared/services/pharmacist.service.ts
@@ -22,7 +22,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { environment } from 'src/environments/environment';
 
 @Injectable()

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.ts
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.ts
@@ -39,7 +39,7 @@ import { SetLanguageComponent } from '../../core/components/set-language.compone
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-worklist',

--- a/src/app/app-modules/registrar/registration/editRegistration.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/editRegistration.component.spec.ts
@@ -33,7 +33,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { CameraService } from '../../core/services/camera.service';
-import { RegistrarService } from '../../../../../Common-UI/src/registrar/services/registrar.service';
+import { RegistrarService } from '../../../../../Common-UI/v2/registrar/services/registrar.service';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/empty';

--- a/src/app/app-modules/registrar/registration/editWrongRegistration.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/editWrongRegistration.component.spec.ts
@@ -26,7 +26,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { CameraService } from '../../core/services/camera.service';
-import { RegistrarService } from '../../../../../Common-UI/src/registrar/services/registrar.service';
+import { RegistrarService } from '../../../../../Common-UI/v2/registrar/services/registrar.service';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/empty';

--- a/src/app/app-modules/registrar/registration/register-demographic-details/register-demographic-details.component.ts
+++ b/src/app/app-modules/registrar/registration/register-demographic-details/register-demographic-details.component.ts
@@ -35,7 +35,7 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { RegisterEditLocationComponent } from '../register-edit-location/register-edit-location.component';
 import { _MatAutocompleteBase } from '@angular/material/autocomplete';
 import { RegistrarService } from '../../shared/services/registrar.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-register-demographic-details',

--- a/src/app/app-modules/registrar/registration/register-edit-location/register-edit-location.component.ts
+++ b/src/app/app-modules/registrar/registration/register-edit-location/register-edit-location.component.ts
@@ -27,8 +27,8 @@ import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-la
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../shared/services/registrar.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-register-edit-location',

--- a/src/app/app-modules/registrar/registration/register-other-details/register-other-details.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/register-other-details/register-other-details.component.spec.ts
@@ -31,7 +31,7 @@ import {
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { CameraService } from '../../../core/services/camera.service';
-import { RegistrarService } from '../../../../../../Common-UI/src/registrar/services/registrar.service';
+import { RegistrarService } from '../../../../../../Common-UI/v2/registrar/services/registrar.service';
 import { RegistrationUtils } from '../../shared/utility/registration-utility';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';

--- a/src/app/app-modules/registrar/registration/register-personal-details/register-personal-details.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/register-personal-details/register-personal-details.component.spec.ts
@@ -31,7 +31,7 @@ import {
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { CameraService } from '../../../core/services/camera.service';
-import { RegistrarService } from '../../../../../../Common-UI/src/registrar/services/registrar.service';
+import { RegistrarService } from '../../../../../../Common-UI/v2/registrar/services/registrar.service';
 import { RegistrationUtils } from '../../shared/utility/registration-utility';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';

--- a/src/app/app-modules/registrar/registration/register-personal-details/register-personal-details.component.ts
+++ b/src/app/app-modules/registrar/registration/register-personal-details/register-personal-details.component.ts
@@ -36,7 +36,7 @@ import { CameraService } from '../../../core/services/camera.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { BeneficiaryDetailsService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 import {
   BsDatepickerConfig,
   BsDatepickerDirective,

--- a/src/app/app-modules/registrar/registration/registration.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/registration.component.spec.ts
@@ -33,7 +33,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { CameraService } from '../../core/services/camera.service';
-import { RegistrarService } from '../../../../../Common-UI/src/registrar/services/registrar.service';
+import { RegistrarService } from '../../../../../Common-UI/v2/registrar/services/registrar.service';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/empty';

--- a/src/app/app-modules/registrar/registration/registration.component.ts
+++ b/src/app/app-modules/registrar/registration/registration.component.ts
@@ -42,7 +42,7 @@ import { SetLanguageComponent } from '../../core/components/set-language.compone
 import { Observable } from 'rxjs/internal/Observable';
 import { of } from 'rxjs';
 import { RegistrarService } from '../shared/services/registrar.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-registration',

--- a/src/app/app-modules/registrar/search-dialog/search-dialog.component.ts
+++ b/src/app/app-modules/registrar/search-dialog/search-dialog.component.ts
@@ -45,7 +45,7 @@ import {
   MomentDateAdapter,
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
 } from '@angular/material-moment-adapter';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 interface Beneficary {
   firstName: string;

--- a/src/app/app-modules/registrar/search/search.component.ts
+++ b/src/app/app-modules/registrar/search/search.component.ts
@@ -39,7 +39,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-search',

--- a/src/app/app-modules/reset-password/reset-password.component.ts
+++ b/src/app/app-modules/reset-password/reset-password.component.ts
@@ -24,7 +24,7 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { ConfirmationService } from '../core/services/confirmation.service';
 import { AuthService } from '../core/services';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-reset-password',

--- a/src/app/app-modules/service-point/service-point-resolve.service.ts
+++ b/src/app/app-modules/service-point/service-point-resolve.service.ts
@@ -25,7 +25,7 @@ import { Router, Resolve, ActivatedRouteSnapshot } from '@angular/router';
 
 import { ServicePointService } from './service-point.service';
 import { map } from 'rxjs';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Injectable()
 export class ServicePointResolve implements Resolve<any> {

--- a/src/app/app-modules/service-point/service-point.component.ts
+++ b/src/app/app-modules/service-point/service-point.component.ts
@@ -28,8 +28,8 @@ import { HttpServiceService } from '../core/services/http-service.service';
 import { ServicePointService } from './service-point.service';
 import { FormBuilder, Validators } from '@angular/forms';
 import { RegistrarService } from '../registrar/shared/services/registrar.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-service-point',

--- a/src/app/app-modules/service-point/service-point.service.ts
+++ b/src/app/app-modules/service-point/service-point.service.ts
@@ -23,7 +23,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { environment } from 'src/environments/environment';
 
 @Injectable()

--- a/src/app/app-modules/service/service.component.ts
+++ b/src/app/app-modules/service/service.component.ts
@@ -25,7 +25,7 @@ import { Router } from '@angular/router';
 import { SetLanguageComponent } from '../core/components/set-language.component';
 import { ConfirmationService } from '../core/services';
 import { HttpServiceService } from '../core/services/http-service.service';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-service',

--- a/src/app/app-modules/set-password/set-password.component.ts
+++ b/src/app/app-modules/set-password/set-password.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import * as CryptoJS from 'crypto-js';
 import {
   AuthService,

--- a/src/app/app-modules/set-security-questions/set-security-questions.component.ts
+++ b/src/app/app-modules/set-security-questions/set-security-questions.component.ts
@@ -24,7 +24,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import * as CryptoJS from 'crypto-js';
 import { AuthService, ConfirmationService } from '../core/services';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-set-security-questions',

--- a/src/app/app-modules/tm-logout/tm-logout.component.ts
+++ b/src/app/app-modules/tm-logout/tm-logout.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Component({
   selector: 'app-tm-logout',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -75,7 +75,7 @@ const routes: Routes = [
     path: 'registrar',
     canActivate: [AuthGuard],
     loadChildren: () =>
-      import('Common-UI/src/registrar/registration.module').then(
+      import('Common-UI/v2/registrar/registration.module').then(
         module => module.RegistrationModule
       ),
   },
@@ -112,7 +112,7 @@ const routes: Routes = [
   {
     path: 'feedback',
     loadChildren: () =>
-      import('Common-UI/src/feedback/feedback.module').then(
+      import('Common-UI/v2/feedback/feedback.module').then(
         m => m.FeedbackModule
       ),
   },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -31,7 +31,7 @@ import {
   Router,
 } from '@angular/router';
 import { SpinnerService } from './app-modules/core/services';
-import { AmritTrackingService } from 'Common-UI/src/tracking';
+import { AmritTrackingService } from 'Common-UI/v2/tracking';
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,7 +38,7 @@ import { SharedModule } from './app-modules/core/components/shared/shared.module
 import { CommonModule } from '@angular/common';
 import { CaptchaComponent } from './app-modules/captcha/captcha.component';
 import { MatChipsModule } from '@angular/material/chips';
-import { TrackingModule } from 'Common-UI/src/tracking';
+import { TrackingModule } from 'Common-UI/v2/tracking';
 
 @NgModule({
   declarations: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
       "dom"
     ],
     "paths": {
-      "Common-UI/src/*": ["Common-UI/src/*"]
+      "Common-UI/v2/*": ["Common-UI/v2/*"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## Description

Common-UI is a shared library used by **MMU, HWC, and ECD**. To avoid forcing the Angular upgrade onto the other consumers, the migrated Common-UI code now lives in a new **`v2/`** folder, while the original **`src/`** stays on Angular 16. This PR switches MMU-UI to consume `Common-UI/v2`.

## Why a v2 folder (instead of migrating `src/` in place)

Upgrading `src/` directly would force Angular 19 + `standalone: false` onto HWC/ECD/AAM. The v2 approach lets each consumer migrate independently:

* `Common-UI/src/` → Angular 16 (untouched — HWC, ECD, AAM)
* `Common-UI/v2/` → migrated (standalone: false, provideHttpClient, waitForAsync) — MMU

When all consumers move to v2, the old `src/` can be removed.

## Steps

1. Repointed all MMU-UI imports `Common-UI/src/...` → `Common-UI/v2/...` (136 files).
2. Updated the `tsconfig.json` path alias `"Common-UI/src/*"` → `"Common-UI/v2/*"`.
3. Bumped the Common-UI submodule pointer to the branch that adds `v2/`.

## Verification

* `npm run build-prod` → 0 errors, same 9-warning profile. MMU resolves against `Common-UI/v2/`.
* Original `Common-UI/src/` confirmed untouched (imports intact for the other repos).

## Note

* `v2/` content is the 16 → 19 migration already completed on Common-UI's `angular-zard-migration` branch.
* Depends on the Common-UI v2 PR (the bumped submodule pointer references that branch).
