### PR TITLE
chore(core): remove leftover app-footer from data-sync & nurse-doctor dashboards

### DIFF
--- a/src/app/app-modules/data-sync/dashboard/dashboard.component.html
+++ b/src/app/app-modules/data-sync/dashboard/dashboard.component.html
@@ -1,5 +1,3 @@
 <app-header [showRoles]="true"></app-header>
 
 <router-outlet></router-outlet>
-
-<app-footer></app-footer>

--- a/src/app/app-modules/data-sync/dashboard/dashboard.component.ts
+++ b/src/app/app-modules/data-sync/dashboard/dashboard.component.ts
@@ -23,13 +23,12 @@
 import { Component } from '@angular/core';
 import { AppHeaderComponent } from '../../core/components/app-header/app-header.component';
 import { RouterOutlet } from '@angular/router';
-import { AppFooterComponent } from '../../core/components/app-footer/app-footer.component';
 
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
-  imports: [AppHeaderComponent, RouterOutlet, AppFooterComponent],
+  imports: [AppHeaderComponent, RouterOutlet],
 })
 export class DashboardComponent {
   constructor() {}

--- a/src/app/app-modules/nurse-doctor/dashboard/dashboard.component.html
+++ b/src/app/app-modules/nurse-doctor/dashboard/dashboard.component.html
@@ -1,5 +1,3 @@
 <app-header [showRoles]="true"></app-header>
 
 <router-outlet></router-outlet>
-
-<app-footer></app-footer>

--- a/src/app/app-modules/nurse-doctor/dashboard/dashboard.component.ts
+++ b/src/app/app-modules/nurse-doctor/dashboard/dashboard.component.ts
@@ -23,13 +23,12 @@
 import { Component } from '@angular/core';
 import { AppHeaderComponent } from '../../core/components/app-header/app-header.component';
 import { RouterOutlet } from '@angular/router';
-import { AppFooterComponent } from '../../core/components/app-footer/app-footer.component';
 
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
-  imports: [AppHeaderComponent, RouterOutlet, AppFooterComponent],
+  imports: [AppHeaderComponent, RouterOutlet],
 })
 export class DashboardComponent {
   constructor() {}


### PR DESCRIPTION
## What & why
The global footer bar was removed app-wide in #380 (`app-footer` renders nothing). This drops the now-dead `<app-footer>` tag + import from the two remaining shell dashboards — **data-sync** and **nurse-doctor** — so they no longer reference the empty component.

(The service / pharmacist / lab dashboards have their `<app-footer>` removed in PRs #381 / #382 / #383.)

## Changes
- `data-sync/dashboard`: remove `<app-footer>` + `AppFooterComponent` import.
- `nurse-doctor/dashboard`: same.

No behaviour change.