### PR TITLE
refactor(worklist): shared app-beneficiary-worklist component

### DIFF
--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
@@ -43,13 +43,45 @@
               *ngFor="let row of pagedList; let i = index"
               (click)="rowClick.emit(row)"
               (keydown.enter)="rowClick.emit(row)">
-              <ng-container *ngIf="rowTemplate; else standardRow">
+              <ng-container *ngIf="rowTemplate; else builtinRow">
                 <ng-container
                   *ngTemplateOutlet="
                     rowTemplate;
                     context: { $implicit: row, sno: serial(i) }
                   "></ng-container>
               </ng-container>
+              <ng-template #builtinRow>
+                <ng-container *ngIf="visitStatus; else standardRow">
+                  <td
+                    z-table-cell
+                    class="border-l-[3px] font-semibold"
+                    [ngClass]="
+                      row.benVisitNo === 1
+                        ? 'border-l-success'
+                        : 'border-l-warning'
+                    ">
+                    {{ serial(i) }}
+                  </td>
+                  <td z-table-cell>{{ row.beneficiaryID }}</td>
+                  <td z-table-cell>{{ row.benName | titlecase }}</td>
+                  <td z-table-cell>{{ row.genderName | titlecase }}</td>
+                  <td z-table-cell>{{ row.age }}</td>
+                  <td z-table-cell>
+                    {{ row.benVisitNo === 1 ? firstVisitText : reVisitText }}
+                  </td>
+                  <td z-table-cell>{{ row.fatherName | titlecase }}</td>
+                  <td z-table-cell>
+                    {{ row.districtName | titlecase }} /
+                    {{ row.villageName | titlecase }}
+                  </td>
+                  <td z-table-cell>{{ row.preferredPhoneNum }}</td>
+                  <ng-container
+                    *ngTemplateOutlet="
+                      imageCell;
+                      context: { $implicit: row }
+                    "></ng-container>
+                </ng-container>
+              </ng-template>
               <ng-template #standardRow>
                 <td z-table-cell>{{ serial(i) }}</td>
                 <td z-table-cell>{{ row.beneficiaryID }}</td>
@@ -68,22 +100,11 @@
                 </td>
                 <td z-table-cell>{{ row.preferredPhoneNum }}</td>
                 <td z-table-cell>{{ row.benVisitDate }}</td>
-                <td z-table-cell>
-                  <button
-                    type="button"
-                    class="inline-flex appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    [zTooltip]="imageTooltip"
-                    (click)="
-                      $event.stopPropagation();
-                      imageClick.emit(row.beneficiaryRegID)
-                    "
-                    (keydown.enter)="$event.stopPropagation()">
-                    <img
-                      class="size-[1.875rem] rounded-full object-cover"
-                      src="assets/images/Avatar-Profile_30X30.png"
-                      alt="profile" />
-                  </button>
-                </td>
+                <ng-container
+                  *ngTemplateOutlet="
+                    imageCell;
+                    context: { $implicit: row }
+                  "></ng-container>
               </ng-template>
             </tr>
             <tr z-table-row *ngIf="filteredData.length === 0">
@@ -98,11 +119,41 @@
         </table>
       </div>
 
+      <ng-template #imageCell let-row>
+        <td z-table-cell>
+          <button
+            type="button"
+            class="inline-flex appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            [zTooltip]="imageTooltip"
+            (click)="
+              $event.stopPropagation(); imageClick.emit(row.beneficiaryRegID)
+            "
+            (keydown.enter)="$event.stopPropagation()">
+            <img
+              class="size-[1.875rem] rounded-full object-cover"
+              src="assets/images/Avatar-Profile_30X30.png"
+              alt="profile" />
+          </button>
+        </td>
+      </ng-template>
+
       <div
         class="mt-4 flex flex-wrap items-center justify-between gap-4 px-2"
         *ngIf="filteredData.length > 0">
         <ng-container *ngTemplateOutlet="footerStart"></ng-container>
-        <span *ngIf="!footerStart" aria-hidden="true"></span>
+        <ul
+          *ngIf="!footerStart && visitStatus"
+          class="m-0 flex list-none items-center gap-5 p-0 text-[0.8125rem] text-muted-foreground">
+          <li class="inline-flex items-center gap-1.5">
+            <span class="size-3 rounded bg-success"></span>
+            {{ firstVisitText }}
+          </li>
+          <li class="inline-flex items-center gap-1.5">
+            <span class="size-3 rounded bg-warning"></span>
+            {{ reVisitText }}
+          </li>
+        </ul>
+        <span *ngIf="!footerStart && !visitStatus" aria-hidden="true"></span>
 
         <div class="flex flex-wrap items-center gap-4">
           <div

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
@@ -1,9 +1,7 @@
 <div class="px-6 pb-10 pt-3">
   <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
     <div class="relative flex max-w-96 flex-1 basis-72 items-center">
-      <label class="sr-only" for="worklist-search">{{
-        searchPlaceholder
-      }}</label>
+      <label class="sr-only" for="worklist-search">{{ searchLabel }}</label>
       <ng-icon
         class="pointer-events-none absolute left-2.5 text-muted-foreground"
         name="lucideSearch"
@@ -14,7 +12,7 @@
         type="search"
         class="w-full bg-background pl-9"
         autocomplete="off"
-        [placeholder]="searchPlaceholder"
+        [placeholder]="searchLabel"
         name="filterTerm"
         [(ngModel)]="filterTerm"
         (ngModelChange)="applyFilter($event)" />
@@ -22,7 +20,7 @@
 
     <button z-button zType="outline" type="button" (click)="refresh.emit()">
       <ng-icon name="lucideRefreshCw"></ng-icon>
-      {{ refreshLabel }}
+      {{ refreshText }}
     </button>
   </div>
 
@@ -32,7 +30,9 @@
         <table z-table>
           <thead z-table-header>
             <tr z-table-row>
-              <th z-table-head *ngFor="let header of headers">{{ header }}</th>
+              <th z-table-head *ngFor="let header of effectiveHeaders">
+                {{ header }}
+              </th>
             </tr>
           </thead>
           <tbody z-table-body>
@@ -43,21 +43,55 @@
               *ngFor="let row of pagedList; let i = index"
               (click)="rowClick.emit(row)"
               (keydown.enter)="rowClick.emit(row)">
-              <ng-container
-                *ngTemplateOutlet="
-                  rowTemplate;
-                  context: {
-                    $implicit: row,
-                    sno: (currentPage - 1) * pageSize + i + 1,
-                  }
-                "></ng-container>
+              <ng-container *ngIf="rowTemplate; else standardRow">
+                <ng-container
+                  *ngTemplateOutlet="
+                    rowTemplate;
+                    context: { $implicit: row, sno: serial(i) }
+                  "></ng-container>
+              </ng-container>
+              <ng-template #standardRow>
+                <td z-table-cell>{{ serial(i) }}</td>
+                <td z-table-cell>{{ row.beneficiaryID }}</td>
+                <td z-table-cell>{{ row.benName | titlecase }}</td>
+                <td z-table-cell>{{ row.genderName | titlecase }}</td>
+                <td z-table-cell>{{ row.age }}</td>
+                <td z-table-cell>
+                  {{ row.VisitCategory }} /
+                  <span class="text-muted-foreground">{{
+                    row.benVisitNo
+                  }}</span>
+                </td>
+                <td z-table-cell>
+                  {{ row.districtName | titlecase }} /
+                  {{ row.villageName | titlecase }}
+                </td>
+                <td z-table-cell>{{ row.preferredPhoneNum }}</td>
+                <td z-table-cell>{{ row.benVisitDate }}</td>
+                <td z-table-cell>
+                  <button
+                    type="button"
+                    class="inline-flex appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    [zTooltip]="imageTooltip"
+                    (click)="
+                      $event.stopPropagation();
+                      imageClick.emit(row.beneficiaryRegID)
+                    "
+                    (keydown.enter)="$event.stopPropagation()">
+                    <img
+                      class="size-[1.875rem] rounded-full object-cover"
+                      src="assets/images/Avatar-Profile_30X30.png"
+                      alt="profile" />
+                  </button>
+                </td>
+              </ng-template>
             </tr>
             <tr z-table-row *ngIf="filteredData.length === 0">
               <td
                 z-table-cell
-                [attr.colspan]="headers.length"
+                [attr.colspan]="effectiveHeaders.length"
                 class="h-24 text-center text-muted-foreground">
-                {{ emptyLabel }}
+                {{ emptyText }}
               </td>
             </tr>
           </tbody>
@@ -73,7 +107,7 @@
         <div class="flex flex-wrap items-center gap-4">
           <div
             class="inline-flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
-            <span>{{ rowsPerPageLabel }}</span>
+            <span>{{ rowsPerPageText }}</span>
             <z-select
               class="w-[4.5rem]"
               name="pageSize"

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
@@ -40,13 +40,16 @@
               z-table-row
               class="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
               tabindex="0"
-              *ngFor="let row of pagedList"
+              *ngFor="let row of pagedList; let i = index"
               (click)="rowClick.emit(row)"
               (keydown.enter)="rowClick.emit(row)">
               <ng-container
                 *ngTemplateOutlet="
                   rowTemplate;
-                  context: { $implicit: row }
+                  context: {
+                    $implicit: row,
+                    sno: (currentPage - 1) * pageSize + i + 1,
+                  }
                 "></ng-container>
             </tr>
             <tr z-table-row *ngIf="filteredData.length === 0">

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
@@ -1,12 +1,16 @@
 <div class="px-6 pb-10 pt-3">
   <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
     <div class="relative flex max-w-96 flex-1 basis-72 items-center">
+      <label class="sr-only" for="worklist-search">{{
+        searchPlaceholder
+      }}</label>
       <ng-icon
         class="pointer-events-none absolute left-2.5 text-muted-foreground"
         name="lucideSearch"
         size="18"></ng-icon>
       <input
         z-input
+        id="worklist-search"
         type="search"
         class="w-full bg-background pl-9"
         autocomplete="off"

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
@@ -1,0 +1,115 @@
+<div class="px-6 pb-10 pt-3">
+  <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+    <div class="relative flex max-w-96 flex-1 basis-72 items-center">
+      <ng-icon
+        class="pointer-events-none absolute left-2.5 text-muted-foreground"
+        name="lucideSearch"
+        size="18"></ng-icon>
+      <input
+        z-input
+        type="search"
+        class="w-full bg-background pl-9"
+        autocomplete="off"
+        [placeholder]="searchPlaceholder"
+        name="filterTerm"
+        [(ngModel)]="filterTerm"
+        (ngModelChange)="applyFilter($event)" />
+    </div>
+
+    <button z-button zType="outline" type="button" (click)="refresh.emit()">
+      <ng-icon name="lucideRefreshCw"></ng-icon>
+      {{ refreshLabel }}
+    </button>
+  </div>
+
+  <z-card>
+    <z-card-content class="p-2">
+      <div class="w-full overflow-x-auto">
+        <table z-table>
+          <thead z-table-header>
+            <tr z-table-row>
+              <th z-table-head *ngFor="let header of headers">{{ header }}</th>
+            </tr>
+          </thead>
+          <tbody z-table-body>
+            <tr
+              z-table-row
+              class="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              tabindex="0"
+              *ngFor="let row of pagedList"
+              (click)="rowClick.emit(row)"
+              (keydown.enter)="rowClick.emit(row)">
+              <ng-container
+                *ngTemplateOutlet="
+                  rowTemplate;
+                  context: { $implicit: row }
+                "></ng-container>
+            </tr>
+            <tr z-table-row *ngIf="filteredData.length === 0">
+              <td
+                z-table-cell
+                [attr.colspan]="headers.length"
+                class="h-24 text-center text-muted-foreground">
+                {{ emptyLabel }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div
+        class="mt-4 flex flex-wrap items-center justify-between gap-4 px-2"
+        *ngIf="filteredData.length > 0">
+        <ng-container *ngTemplateOutlet="footerStart"></ng-container>
+        <span *ngIf="!footerStart" aria-hidden="true"></span>
+
+        <div class="flex flex-wrap items-center gap-4">
+          <div
+            class="inline-flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
+            <span>{{ rowsPerPageLabel }}</span>
+            <z-select
+              class="w-[4.5rem]"
+              name="pageSize"
+              [zValue]="pageSize.toString()"
+              (zSelectionChange)="changePageSize($event)">
+              <z-select-item
+                *ngFor="let size of pageSizeOptions"
+                [zValue]="size.toString()">
+                {{ size }}
+              </z-select-item>
+            </z-select>
+          </div>
+
+          <ul z-pagination-content class="m-0">
+            <li z-pagination-item>
+              <button
+                z-pagination-button
+                [zDisabled]="currentPage === 1"
+                aria-label="Previous page"
+                (click)="prevPage()">
+                <ng-icon name="lucideChevronLeft" size="16"></ng-icon>
+              </button>
+            </li>
+            <li z-pagination-item *ngFor="let p of pageNumbers">
+              <button
+                z-pagination-button
+                [zActive]="p === currentPage"
+                (click)="goToPage(p)">
+                {{ p }}
+              </button>
+            </li>
+            <li z-pagination-item>
+              <button
+                z-pagination-button
+                [zDisabled]="currentPage === totalPages"
+                aria-label="Next page"
+                (click)="nextPage()">
+                <ng-icon name="lucideChevronRight" size="16"></ng-icon>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </z-card-content>
+  </z-card>
+</div>

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.html
@@ -1,4 +1,4 @@
-<div class="px-6 pb-10 pt-3">
+<div [class]="padded ? 'px-6 pb-10 pt-3' : 'pb-10'">
   <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
     <div class="relative flex max-w-96 flex-1 basis-72 items-center">
       <label class="sr-only" for="worklist-search">{{ searchLabel }}</label>

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
@@ -30,7 +30,7 @@ import {
   TemplateRef,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
+import { NgFor, NgIf, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   lucideSearch,
@@ -44,13 +44,34 @@ import { ZardPaginationImports } from 'Common-UI/v2/ui/pagination';
 import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
 import { ZardInputDirective } from 'Common-UI/v2/ui/input';
 import { ZardSelectImports } from 'Common-UI/v2/ui/select';
+import { tooltipImports } from 'Common-UI/v2/ui/tooltip';
+
+/** Object keys the standard beneficiary worklist filters against. */
+export const STANDARD_WORKLIST_SEARCH_KEYS = [
+  'beneficiaryID',
+  'benName',
+  'genderName',
+  'age',
+  'VisitCategory',
+  'benVisitNo',
+  'districtName',
+  'preferredPhoneNum',
+  'villageName',
+  'beneficiaryRegID',
+  'visitDate',
+  'benVisitDate',
+];
 
 /**
  * Shared presentational shell for the role worklists (pharmacist, lab,
  * nurse, doctor, …). It owns the common chrome — search toolbar, z-card +
- * z-table, client-side filtering and pagination, and the empty state — so
- * each role's worklist is a thin wrapper that supplies its columns, data,
- * row cells and click handler. Routing, services and per-role behaviour
+ * z-table, client-side filtering and pagination, and the empty state.
+ *
+ * For the standard beneficiary columns (used by pharmacist/lab/oncologist/
+ * radiologist) it renders the default cells itself — a consumer only passes
+ * `data` + `currentLanguageSet` and wires `rowClick`/`refresh`/`imageClick`.
+ * Screens with extra/custom columns (nurse, doctor) override `rowTemplate`
+ * (and `headers`/`footerStart`). Routing, services and per-role behaviour
  * stay in the role component.
  */
 @Component({
@@ -62,6 +83,7 @@ import { ZardSelectImports } from 'Common-UI/v2/ui/select';
     NgFor,
     NgIf,
     NgTemplateOutlet,
+    TitleCasePipe,
     NgIcon,
     ZardButtonComponent,
     ZardInputDirective,
@@ -69,6 +91,7 @@ import { ZardSelectImports } from 'Common-UI/v2/ui/select';
     ...ZardTableImports,
     ...ZardPaginationImports,
     ...ZardSelectImports,
+    ...tooltipImports,
   ],
   viewProviders: [
     provideIcons({
@@ -82,35 +105,96 @@ import { ZardSelectImports } from 'Common-UI/v2/ui/select';
 export class BeneficiaryWorklistComponent implements OnChanges {
   /** Full (unfiltered) list of rows; the component filters + paginates it. */
   @Input() data: any[] = [];
-  /** Column header labels (also drives the empty-row colspan). */
-  @Input() headers: string[] = [];
-  /** Object keys the search box filters on. */
-  @Input() searchKeys: string[] = [];
-  /**
-   * Renders the <td> cells for one row. Template context: `$implicit` is the
-   * row and `sno` is its 1-based serial number for the current page.
-   */
-  @Input() rowTemplate!: TemplateRef<{ $implicit: any; sno: number }>;
+  /** Language set; drives the default headers, labels and image tooltip. */
+  @Input() currentLanguageSet: any = null;
+  /** Override the default standard headers. */
+  @Input() headers: string[] | null = null;
+  /** Override the default search keys. */
+  @Input() searchKeys: string[] | null = null;
+  /** Override the default standard cells with a custom row (context: row, sno). */
+  @Input() rowTemplate: TemplateRef<{ $implicit: any; sno: number }> | null =
+    null;
   /** Optional left-aligned footer content (e.g. a status legend / total). */
   @Input() footerStart: TemplateRef<unknown> | null = null;
   /** Optional extra match for derived/computed columns (e.g. visit status). */
   @Input() extraSearch: ((item: any, term: string) => boolean) | null = null;
 
-  @Input() searchPlaceholder = 'Search';
-  @Input() refreshLabel = 'Refresh';
-  @Input() emptyLabel = 'No Records Found';
-  @Input() rowsPerPageLabel = 'Rows per page';
+  /** Optional label overrides (otherwise derived from currentLanguageSet). */
+  @Input() searchPlaceholder?: string;
+  @Input() refreshLabel?: string;
+  @Input() emptyLabel?: string;
+  @Input() rowsPerPageLabel?: string;
 
   /** Emitted when a row is clicked or activated via keyboard. */
   @Output() rowClick = new EventEmitter<any>();
   /** Emitted when the refresh button is pressed. */
   @Output() refresh = new EventEmitter<void>();
+  /** Emitted by the default image cell with the row's beneficiaryRegID. */
+  @Output() imageClick = new EventEmitter<any>();
 
   filterTerm = '';
   filteredData: any[] = [];
   pageSizeOptions = [5, 10, 20];
   pageSize = 5;
   currentPage = 1;
+
+  get effectiveHeaders(): string[] {
+    if (this.headers?.length) return this.headers;
+    const b = this.currentLanguageSet?.bendetails;
+    const c = this.currentLanguageSet?.casesheet;
+    return [
+      c?.serialNo,
+      b?.beneficiaryID,
+      b?.beneficiaryName,
+      b?.gender,
+      b?.age,
+      b?.visitCategory,
+      b?.district,
+      b?.phoneNo,
+      b?.visitDate,
+      b?.image,
+    ];
+  }
+
+  get effectiveSearchKeys(): string[] {
+    return this.searchKeys?.length
+      ? this.searchKeys
+      : STANDARD_WORKLIST_SEARCH_KEYS;
+  }
+
+  get searchLabel(): string {
+    return (
+      this.searchPlaceholder ??
+      this.currentLanguageSet?.common?.inTableSearch ??
+      'Search'
+    );
+  }
+
+  get refreshText(): string {
+    return (
+      this.refreshLabel ?? this.currentLanguageSet?.common?.refresh ?? 'Refresh'
+    );
+  }
+
+  get emptyText(): string {
+    return (
+      this.emptyLabel ??
+      this.currentLanguageSet?.noRecordsFound ??
+      'No Records Found'
+    );
+  }
+
+  get rowsPerPageText(): string {
+    return (
+      this.rowsPerPageLabel ??
+      this.currentLanguageSet?.common?.rowsPerPage ??
+      'Rows per page'
+    );
+  }
+
+  get imageTooltip(): string {
+    return this.currentLanguageSet?.tc?.image ?? 'View image';
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     // Re-filter only when the underlying data changes, so header/template
@@ -125,17 +209,22 @@ export class BeneficiaryWorklistComponent implements OnChanges {
     const t = (term || '').toLowerCase().trim();
     let list = this.data ?? [];
     if (t) {
+      const keys = this.effectiveSearchKeys;
       list = list.filter(
         item =>
-          this.searchKeys.some(key =>
-            ('' + item[key]).toLowerCase().includes(t)
-          ) || (this.extraSearch ? this.extraSearch(item, t) : false)
+          keys.some(key => ('' + item[key]).toLowerCase().includes(t)) ||
+          (this.extraSearch ? this.extraSearch(item, t) : false)
       );
     }
-    // Serial numbers are passed to the row template via context (see the
-    // template) rather than mutated onto the parent-owned row objects.
+    // Serial numbers are passed to the row via context / computed for the
+    // default cells, never mutated onto the parent-owned row objects.
     this.filteredData = list;
     this.currentPage = 1;
+  }
+
+  /** 1-based serial number for the row at page-index `i`. */
+  serial(i: number): number {
+    return (this.currentPage - 1) * this.pageSize + i + 1;
   }
 
   get totalPages(): number {

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
@@ -1,0 +1,174 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technology
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  TemplateRef,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  lucideSearch,
+  lucideRefreshCw,
+  lucideChevronLeft,
+  lucideChevronRight,
+} from '@ng-icons/lucide';
+import { cardImports } from 'Common-UI/v2/ui/card';
+import { ZardTableImports } from 'Common-UI/v2/ui/table';
+import { ZardPaginationImports } from 'Common-UI/v2/ui/pagination';
+import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
+import { ZardInputDirective } from 'Common-UI/v2/ui/input';
+import { ZardSelectImports } from 'Common-UI/v2/ui/select';
+
+/**
+ * Shared presentational shell for the role worklists (pharmacist, lab,
+ * nurse, doctor, …). It owns the common chrome — search toolbar, z-card +
+ * z-table, client-side filtering and pagination, and the empty state — so
+ * each role's worklist is a thin wrapper that supplies its columns, data,
+ * row cells and click handler. Routing, services and per-role behaviour
+ * stay in the role component.
+ */
+@Component({
+  selector: 'app-beneficiary-worklist',
+  templateUrl: './beneficiary-worklist.component.html',
+  host: { class: 'block' },
+  imports: [
+    FormsModule,
+    NgFor,
+    NgIf,
+    NgTemplateOutlet,
+    NgIcon,
+    ZardButtonComponent,
+    ZardInputDirective,
+    ...cardImports,
+    ...ZardTableImports,
+    ...ZardPaginationImports,
+    ...ZardSelectImports,
+  ],
+  viewProviders: [
+    provideIcons({
+      lucideSearch,
+      lucideRefreshCw,
+      lucideChevronLeft,
+      lucideChevronRight,
+    }),
+  ],
+})
+export class BeneficiaryWorklistComponent implements OnChanges {
+  /** Full (unfiltered) list of rows; the component filters + paginates it. */
+  @Input() data: any[] = [];
+  /** Column header labels (also drives the empty-row colspan). */
+  @Input() headers: string[] = [];
+  /** Object keys the search box filters on. */
+  @Input() searchKeys: string[] = [];
+  /** Renders the <td> cells for one row; context `$implicit` is the row. */
+  @Input() rowTemplate!: TemplateRef<{ $implicit: any }>;
+  /** Optional left-aligned footer content (e.g. a status legend / total). */
+  @Input() footerStart: TemplateRef<unknown> | null = null;
+  /** Optional extra match for derived/computed columns (e.g. visit status). */
+  @Input() extraSearch: ((item: any, term: string) => boolean) | null = null;
+
+  @Input() searchPlaceholder = 'Search';
+  @Input() refreshLabel = 'Refresh';
+  @Input() emptyLabel = 'No Records Found';
+  @Input() rowsPerPageLabel = 'Rows per page';
+
+  /** Emitted when a row is clicked or activated via keyboard. */
+  @Output() rowClick = new EventEmitter<any>();
+  /** Emitted when the refresh button is pressed. */
+  @Output() refresh = new EventEmitter<void>();
+
+  filterTerm = '';
+  filteredData: any[] = [];
+  pageSizeOptions = [5, 10, 20];
+  pageSize = 5;
+  currentPage = 1;
+
+  ngOnChanges(changes: SimpleChanges) {
+    // Re-filter only when the underlying data changes, so header/template
+    // input churn (re-evaluated on change detection) doesn't reset the page.
+    if (changes['data']) {
+      this.applyFilter(this.filterTerm);
+    }
+  }
+
+  applyFilter(term: string) {
+    this.filterTerm = term;
+    const t = (term || '').toLowerCase().trim();
+    let list = this.data ?? [];
+    if (t) {
+      list = list.filter(
+        item =>
+          this.searchKeys.some(key =>
+            ('' + item[key]).toLowerCase().includes(t)
+          ) || (this.extraSearch ? this.extraSearch(item, t) : false)
+      );
+    }
+    list.forEach((item, index) => (item.sno = index + 1));
+    this.filteredData = list;
+    this.currentPage = 1;
+  }
+
+  get totalPages(): number {
+    return Math.max(1, Math.ceil(this.filteredData.length / this.pageSize));
+  }
+
+  get pagedList(): any[] {
+    const start = (this.currentPage - 1) * this.pageSize;
+    return this.filteredData.slice(start, start + this.pageSize);
+  }
+
+  /** A small window of page numbers around the current page (max 5). */
+  get pageNumbers(): number[] {
+    const total = this.totalPages;
+    let start = Math.max(1, this.currentPage - 2);
+    const end = Math.min(total, start + 4);
+    start = Math.max(1, end - 4);
+    const pages: number[] = [];
+    for (let i = start; i <= end; i++) pages.push(i);
+    return pages;
+  }
+
+  goToPage(page: number) {
+    if (page >= 1 && page <= this.totalPages) this.currentPage = page;
+  }
+
+  prevPage() {
+    if (this.currentPage > 1) this.currentPage--;
+  }
+
+  nextPage() {
+    if (this.currentPage < this.totalPages) this.currentPage++;
+  }
+
+  changePageSize(size: string | string[]) {
+    const value = Array.isArray(size) ? size[0] : size;
+    this.pageSize = Number(value);
+    this.currentPage = 1;
+  }
+}

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
@@ -119,6 +119,9 @@ export class BeneficiaryWorklistComponent implements OnChanges {
   /** Optional extra match for derived/computed columns (e.g. visit status). */
   @Input() extraSearch: ((item: any, term: string) => boolean) | null = null;
 
+  /** When false, drops the outer page padding (e.g. when embedded in tabs). */
+  @Input() padded = true;
+
   /** Optional label overrides (otherwise derived from currentLanguageSet). */
   @Input() searchPlaceholder?: string;
   @Input() refreshLabel?: string;

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
@@ -86,8 +86,11 @@ export class BeneficiaryWorklistComponent implements OnChanges {
   @Input() headers: string[] = [];
   /** Object keys the search box filters on. */
   @Input() searchKeys: string[] = [];
-  /** Renders the <td> cells for one row; context `$implicit` is the row. */
-  @Input() rowTemplate!: TemplateRef<{ $implicit: any }>;
+  /**
+   * Renders the <td> cells for one row. Template context: `$implicit` is the
+   * row and `sno` is its 1-based serial number for the current page.
+   */
+  @Input() rowTemplate!: TemplateRef<{ $implicit: any; sno: number }>;
   /** Optional left-aligned footer content (e.g. a status legend / total). */
   @Input() footerStart: TemplateRef<unknown> | null = null;
   /** Optional extra match for derived/computed columns (e.g. visit status). */
@@ -129,7 +132,8 @@ export class BeneficiaryWorklistComponent implements OnChanges {
           ) || (this.extraSearch ? this.extraSearch(item, t) : false)
       );
     }
-    list.forEach((item, index) => (item.sno = index + 1));
+    // Serial numbers are passed to the row template via context (see the
+    // template) rather than mutated onto the parent-owned row objects.
     this.filteredData = list;
     this.currentPage = 1;
   }

--- a/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
+++ b/src/app/app-modules/core/components/beneficiary-worklist/beneficiary-worklist.component.ts
@@ -30,7 +30,13 @@ import {
   TemplateRef,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NgFor, NgIf, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
+import {
+  NgClass,
+  NgFor,
+  NgIf,
+  NgTemplateOutlet,
+  TitleCasePipe,
+} from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   lucideSearch,
@@ -62,6 +68,17 @@ export const STANDARD_WORKLIST_SEARCH_KEYS = [
   'benVisitDate',
 ];
 
+/** Object keys the nurse "visit status" worklist filters against. */
+export const VISIT_STATUS_SEARCH_KEYS = [
+  'beneficiaryID',
+  'benName',
+  'genderName',
+  'fatherName',
+  'districtName',
+  'preferredPhoneNum',
+  'villageName',
+];
+
 /**
  * Shared presentational shell for the role worklists (pharmacist, lab,
  * nurse, doctor, …). It owns the common chrome — search toolbar, z-card +
@@ -80,6 +97,7 @@ export const STANDARD_WORKLIST_SEARCH_KEYS = [
   host: { class: 'block' },
   imports: [
     FormsModule,
+    NgClass,
     NgFor,
     NgIf,
     NgTemplateOutlet,
@@ -122,6 +140,14 @@ export class BeneficiaryWorklistComponent implements OnChanges {
   /** When false, drops the outer page padding (e.g. when embedded in tabs). */
   @Input() padded = true;
 
+  /**
+   * Nurse "visit status" mode: renders the status-coloured row (first
+   * visit / revisit), the matching headers, the first-visit/revisit legend,
+   * and matches the derived status text when searching — so the nurse
+   * worklists don't each duplicate that markup.
+   */
+  @Input() visitStatus = false;
+
   /** Optional label overrides (otherwise derived from currentLanguageSet). */
   @Input() searchPlaceholder?: string;
   @Input() refreshLabel?: string;
@@ -145,6 +171,20 @@ export class BeneficiaryWorklistComponent implements OnChanges {
     if (this.headers?.length) return this.headers;
     const b = this.currentLanguageSet?.bendetails;
     const c = this.currentLanguageSet?.casesheet;
+    if (this.visitStatus) {
+      return [
+        c?.serialNo,
+        b?.beneficiaryID,
+        b?.beneficiaryName,
+        b?.gender,
+        b?.age,
+        b?.status,
+        b?.fatherName,
+        b?.district,
+        b?.phoneNo,
+        b?.image,
+      ];
+    }
     return [
       c?.serialNo,
       b?.beneficiaryID,
@@ -160,9 +200,19 @@ export class BeneficiaryWorklistComponent implements OnChanges {
   }
 
   get effectiveSearchKeys(): string[] {
-    return this.searchKeys?.length
-      ? this.searchKeys
+    if (this.searchKeys?.length) return this.searchKeys;
+    return this.visitStatus
+      ? VISIT_STATUS_SEARCH_KEYS
       : STANDARD_WORKLIST_SEARCH_KEYS;
+  }
+
+  /** Legend / status labels (fall back to English when no language set). */
+  get firstVisitText(): string {
+    return this.currentLanguageSet?.common?.firstVisit ?? 'First visit';
+  }
+
+  get reVisitText(): string {
+    return this.currentLanguageSet?.common?.reVisit ?? 'Revisit';
   }
 
   get searchLabel(): string {
@@ -216,7 +266,9 @@ export class BeneficiaryWorklistComponent implements OnChanges {
       list = list.filter(
         item =>
           keys.some(key => ('' + item[key]).toLowerCase().includes(t)) ||
-          (this.extraSearch ? this.extraSearch(item, t) : false)
+          (this.extraSearch ? this.extraSearch(item, t) : false) ||
+          (this.visitStatus &&
+            (item.benVisitNo === 1 ? 'first visit' : 'revisit').includes(t))
       );
     }
     // Serial numbers are passed to the row via context / computed for the

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.html
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.html
@@ -11,8 +11,8 @@
   "
   (rowClick)="loadPharmaPage($event)"
   (refresh)="loadPharmaWorklist()">
-  <ng-template #row let-row>
-    <td z-table-cell>{{ row.sno }}</td>
+  <ng-template #row let-row let-sno="sno">
+    <td z-table-cell>{{ sno }}</td>
     <td z-table-cell>{{ row.beneficiaryID }}</td>
     <td z-table-cell>{{ row.benName | titlecase }}</td>
     <td z-table-cell>{{ row.genderName | titlecase }}</td>

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.html
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.html
@@ -1,45 +1,7 @@
 <app-beneficiary-worklist
   [data]="beneficiaryList"
-  [headers]="headers"
-  [searchKeys]="searchKeys"
-  [rowTemplate]="row"
-  [searchPlaceholder]="currentLanguageSet?.common?.inTableSearch || 'Search'"
-  [refreshLabel]="currentLanguageSet?.common?.refresh || 'Refresh'"
-  [emptyLabel]="currentLanguageSet?.noRecordsFound || 'No Records Found'"
-  [rowsPerPageLabel]="
-    currentLanguageSet?.common?.rowsPerPage || 'Rows per page'
-  "
+  [currentLanguageSet]="currentLanguageSet"
   (rowClick)="loadPharmaPage($event)"
-  (refresh)="loadPharmaWorklist()">
-  <ng-template #row let-row let-sno="sno">
-    <td z-table-cell>{{ sno }}</td>
-    <td z-table-cell>{{ row.beneficiaryID }}</td>
-    <td z-table-cell>{{ row.benName | titlecase }}</td>
-    <td z-table-cell>{{ row.genderName | titlecase }}</td>
-    <td z-table-cell>{{ row.age }}</td>
-    <td z-table-cell>
-      {{ row.VisitCategory }} /
-      <span class="text-muted-foreground">{{ row.benVisitNo }}</span>
-    </td>
-    <td z-table-cell>
-      {{ row.districtName | titlecase }} / {{ row.villageName | titlecase }}
-    </td>
-    <td z-table-cell>{{ row.preferredPhoneNum }}</td>
-    <td z-table-cell>{{ row.benVisitDate }}</td>
-    <td z-table-cell>
-      <button
-        type="button"
-        class="inline-flex appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        [zTooltip]="currentLanguageSet?.tc?.image || 'View image'"
-        (click)="
-          $event.stopPropagation(); patientImageView(row.beneficiaryRegID)
-        "
-        (keydown.enter)="$event.stopPropagation()">
-        <img
-          class="size-[1.875rem] rounded-full object-cover"
-          src="assets/images/Avatar-Profile_30X30.png"
-          alt="profile" />
-      </button>
-    </td>
-  </ng-template>
+  (refresh)="loadPharmaWorklist()"
+  (imageClick)="patientImageView($event)">
 </app-beneficiary-worklist>

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.html
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.html
@@ -1,165 +1,45 @@
-<div class="px-6 pb-10 pt-3">
-  <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
-    <div class="relative flex max-w-96 flex-1 basis-72 items-center">
-      <ng-icon
-        class="pointer-events-none absolute left-2.5 text-muted-foreground"
-        name="lucideSearch"
-        size="18"></ng-icon>
-      <input
-        z-input
-        type="search"
-        class="w-full bg-background pl-9"
-        autocomplete="off"
-        [placeholder]="currentLanguageSet?.common?.inTableSearch || 'Search'"
-        name="filterTerm"
-        [(ngModel)]="filterTerm"
-        (ngModelChange)="filterBeneficiaryList($event)" />
-    </div>
-
-    <button
-      z-button
-      zType="outline"
-      type="button"
-      (click)="loadPharmaWorklist()">
-      <ng-icon name="lucideRefreshCw"></ng-icon>
-      {{ currentLanguageSet?.common?.refresh }}
-    </button>
-  </div>
-
-  <z-card>
-    <z-card-content class="p-2">
-      <div class="w-full overflow-x-auto">
-        <table z-table>
-          <thead z-table-header>
-            <tr z-table-row>
-              <th z-table-head>
-                {{ currentLanguageSet?.casesheet?.serialNo }}
-              </th>
-              <th z-table-head>
-                {{ currentLanguageSet?.bendetails?.beneficiaryID }}
-              </th>
-              <th z-table-head>
-                {{ currentLanguageSet?.bendetails?.beneficiaryName }}
-              </th>
-              <th z-table-head>{{ currentLanguageSet?.bendetails?.gender }}</th>
-              <th z-table-head>{{ currentLanguageSet?.bendetails?.age }}</th>
-              <th z-table-head>
-                {{ currentLanguageSet?.bendetails?.visitCategory }}
-              </th>
-              <th z-table-head>
-                {{ currentLanguageSet?.bendetails?.district }}
-              </th>
-              <th z-table-head>
-                {{ currentLanguageSet?.bendetails?.phoneNo }}
-              </th>
-              <th z-table-head>
-                {{ currentLanguageSet?.bendetails?.visitDate }}
-              </th>
-              <th z-table-head>{{ currentLanguageSet?.bendetails?.image }}</th>
-            </tr>
-          </thead>
-          <tbody z-table-body>
-            <tr
-              z-table-row
-              class="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-              tabindex="0"
-              *ngFor="let row of pagedList"
-              (click)="loadPharmaPage(row)"
-              (keydown.enter)="loadPharmaPage(row)">
-              <td z-table-cell>{{ row.sno }}</td>
-              <td z-table-cell>{{ row.beneficiaryID }}</td>
-              <td z-table-cell>{{ row.benName | titlecase }}</td>
-              <td z-table-cell>{{ row.genderName | titlecase }}</td>
-              <td z-table-cell>{{ row.age }}</td>
-              <td z-table-cell>
-                {{ row.VisitCategory }} /
-                <span class="text-muted-foreground">{{ row.benVisitNo }}</span>
-              </td>
-              <td z-table-cell>
-                {{ row.districtName | titlecase }} /
-                {{ row.villageName | titlecase }}
-              </td>
-              <td z-table-cell>{{ row.preferredPhoneNum }}</td>
-              <td z-table-cell>{{ row.benVisitDate }}</td>
-              <td z-table-cell>
-                <button
-                  type="button"
-                  class="inline-flex appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  [zTooltip]="currentLanguageSet?.tc?.image || 'View image'"
-                  (click)="
-                    $event.stopPropagation();
-                    patientImageView(row.beneficiaryRegID)
-                  "
-                  (keydown.enter)="$event.stopPropagation()">
-                  <img
-                    class="size-[1.875rem] rounded-full object-cover"
-                    src="assets/images/Avatar-Profile_30X30.png"
-                    alt="profile" />
-                </button>
-              </td>
-            </tr>
-            <tr z-table-row *ngIf="filteredBeneficiaryList.length === 0">
-              <td
-                z-table-cell
-                colspan="10"
-                class="h-24 text-center text-muted-foreground">
-                {{ currentLanguageSet?.noRecordsFound }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div
-        class="mt-4 flex flex-wrap items-center justify-between gap-4 px-2"
-        *ngIf="filteredBeneficiaryList.length > 0">
-        <div
-          class="inline-flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
-          <span>{{
-            currentLanguageSet?.common?.rowsPerPage || 'Rows per page'
-          }}</span>
-          <z-select
-            class="w-[4.5rem]"
-            name="pageSize"
-            [zValue]="pageSize.toString()"
-            (zSelectionChange)="changePageSize($event)">
-            <z-select-item
-              *ngFor="let size of pageSizeOptions"
-              [zValue]="size.toString()">
-              {{ size }}
-            </z-select-item>
-          </z-select>
-        </div>
-
-        <ul z-pagination-content class="m-0">
-          <li z-pagination-item>
-            <button
-              z-pagination-button
-              [zDisabled]="currentPage === 1"
-              aria-label="Previous page"
-              (click)="prevPage()">
-              <ng-icon name="lucideChevronLeft" size="16"></ng-icon>
-            </button>
-          </li>
-          <li z-pagination-item *ngFor="let p of pageNumbers">
-            <button
-              z-pagination-button
-              [zActive]="p === currentPage"
-              (click)="goToPage(p)">
-              {{ p }}
-            </button>
-          </li>
-          <li z-pagination-item>
-            <button
-              z-pagination-button
-              [zDisabled]="currentPage === totalPages"
-              aria-label="Next page"
-              (click)="nextPage()">
-              <ng-icon name="lucideChevronRight" size="16"></ng-icon>
-            </button>
-          </li>
-        </ul>
-      </div>
-    </z-card-content>
-  </z-card>
-</div>
+<app-beneficiary-worklist
+  [data]="beneficiaryList"
+  [headers]="headers"
+  [searchKeys]="searchKeys"
+  [rowTemplate]="row"
+  [searchPlaceholder]="currentLanguageSet?.common?.inTableSearch || 'Search'"
+  [refreshLabel]="currentLanguageSet?.common?.refresh || 'Refresh'"
+  [emptyLabel]="currentLanguageSet?.noRecordsFound || 'No Records Found'"
+  [rowsPerPageLabel]="
+    currentLanguageSet?.common?.rowsPerPage || 'Rows per page'
+  "
+  (rowClick)="loadPharmaPage($event)"
+  (refresh)="loadPharmaWorklist()">
+  <ng-template #row let-row>
+    <td z-table-cell>{{ row.sno }}</td>
+    <td z-table-cell>{{ row.beneficiaryID }}</td>
+    <td z-table-cell>{{ row.benName | titlecase }}</td>
+    <td z-table-cell>{{ row.genderName | titlecase }}</td>
+    <td z-table-cell>{{ row.age }}</td>
+    <td z-table-cell>
+      {{ row.VisitCategory }} /
+      <span class="text-muted-foreground">{{ row.benVisitNo }}</span>
+    </td>
+    <td z-table-cell>
+      {{ row.districtName | titlecase }} / {{ row.villageName | titlecase }}
+    </td>
+    <td z-table-cell>{{ row.preferredPhoneNum }}</td>
+    <td z-table-cell>{{ row.benVisitDate }}</td>
+    <td z-table-cell>
+      <button
+        type="button"
+        class="inline-flex appearance-none rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        [zTooltip]="currentLanguageSet?.tc?.image || 'View image'"
+        (click)="
+          $event.stopPropagation(); patientImageView(row.beneficiaryRegID)
+        "
+        (keydown.enter)="$event.stopPropagation()">
+        <img
+          class="size-[1.875rem] rounded-full object-cover"
+          src="assets/images/Avatar-Profile_30X30.png"
+          alt="profile" />
+      </button>
+    </td>
+  </ng-template>
+</app-beneficiary-worklist>

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.ts
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.ts
@@ -32,42 +32,18 @@ import * as moment from 'moment';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
-import { TitleCasePipe } from '@angular/common';
-import { ZardTableImports } from 'Common-UI/v2/ui/table';
-import { tooltipImports } from 'Common-UI/v2/ui/tooltip';
 import { BeneficiaryWorklistComponent } from '../../core/components/beneficiary-worklist/beneficiary-worklist.component';
 
 @Component({
   selector: 'app-worklist',
   templateUrl: './worklist.component.html',
   host: { class: 'block' },
-  imports: [
-    TitleCasePipe,
-    BeneficiaryWorklistComponent,
-    ...ZardTableImports,
-    ...tooltipImports,
-  ],
+  imports: [BeneficiaryWorklistComponent],
 })
 export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
   beneficiaryList: any[] = [];
   languageComponent!: SetLanguageComponent;
   currentLanguageSet: any;
-
-  /** Columns the shared worklist may filter against. */
-  readonly searchKeys = [
-    'beneficiaryID',
-    'benName',
-    'genderName',
-    'age',
-    'VisitCategory',
-    'benVisitNo',
-    'districtName',
-    'preferredPhoneNum',
-    'villageName',
-    'beneficiaryRegID',
-    'visitDate',
-    'benVisitDate',
-  ];
 
   constructor(
     private router: Router,
@@ -86,24 +62,6 @@ export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
     this.removeBeneficiaryDataForVisit();
     this.loadPharmaWorklist();
     this.beneficiaryDetailsService.reset();
-  }
-
-  /** Column headers (kept here because they're language-driven). */
-  get headers(): string[] {
-    const b = this.currentLanguageSet?.bendetails;
-    const c = this.currentLanguageSet?.casesheet;
-    return [
-      c?.serialNo,
-      b?.beneficiaryID,
-      b?.beneficiaryName,
-      b?.gender,
-      b?.age,
-      b?.visitCategory,
-      b?.district,
-      b?.phoneNo,
-      b?.visitDate,
-      b?.image,
-    ];
   }
 
   removeBeneficiaryDataForVisit() {

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.ts
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.ts
@@ -32,61 +32,42 @@ import * as moment from 'moment';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
-import { FormsModule } from '@angular/forms';
-import { NgFor, NgIf, TitleCasePipe } from '@angular/common';
-import { NgIcon, provideIcons } from '@ng-icons/core';
-import {
-  lucideSearch,
-  lucideRefreshCw,
-  lucideChevronLeft,
-  lucideChevronRight,
-} from '@ng-icons/lucide';
-import { cardImports } from 'Common-UI/v2/ui/card';
+import { TitleCasePipe } from '@angular/common';
 import { ZardTableImports } from 'Common-UI/v2/ui/table';
-import { ZardPaginationImports } from 'Common-UI/v2/ui/pagination';
-import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
-import { ZardInputDirective } from 'Common-UI/v2/ui/input';
-import { ZardSelectImports } from 'Common-UI/v2/ui/select';
 import { tooltipImports } from 'Common-UI/v2/ui/tooltip';
+import { BeneficiaryWorklistComponent } from '../../core/components/beneficiary-worklist/beneficiary-worklist.component';
 
 @Component({
   selector: 'app-worklist',
   templateUrl: './worklist.component.html',
   host: { class: 'block' },
   imports: [
-    FormsModule,
-    NgFor,
-    NgIf,
     TitleCasePipe,
-    NgIcon,
-    ZardButtonComponent,
-    ZardInputDirective,
-    ...cardImports,
+    BeneficiaryWorklistComponent,
     ...ZardTableImports,
-    ...ZardPaginationImports,
-    ...ZardSelectImports,
     ...tooltipImports,
-  ],
-  viewProviders: [
-    provideIcons({
-      lucideSearch,
-      lucideRefreshCw,
-      lucideChevronLeft,
-      lucideChevronRight,
-    }),
   ],
 })
 export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
   beneficiaryList: any[] = [];
-  filteredBeneficiaryList: any[] = [];
-  filterTerm: any;
   languageComponent!: SetLanguageComponent;
   currentLanguageSet: any;
 
-  // client-side pagination (replaces MatPaginator)
-  pageSizeOptions = [5, 10, 20];
-  pageSize = 5;
-  currentPage = 1;
+  /** Columns the shared worklist may filter against. */
+  readonly searchKeys = [
+    'beneficiaryID',
+    'benName',
+    'genderName',
+    'age',
+    'VisitCategory',
+    'benVisitNo',
+    'districtName',
+    'preferredPhoneNum',
+    'villageName',
+    'beneficiaryRegID',
+    'visitDate',
+    'benVisitDate',
+  ];
 
   constructor(
     private router: Router,
@@ -105,6 +86,24 @@ export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
     this.removeBeneficiaryDataForVisit();
     this.loadPharmaWorklist();
     this.beneficiaryDetailsService.reset();
+  }
+
+  /** Column headers (kept here because they're language-driven). */
+  get headers(): string[] {
+    const b = this.currentLanguageSet?.bendetails;
+    const c = this.currentLanguageSet?.casesheet;
+    return [
+      c?.serialNo,
+      b?.beneficiaryID,
+      b?.beneficiaryName,
+      b?.gender,
+      b?.age,
+      b?.visitCategory,
+      b?.district,
+      b?.phoneNo,
+      b?.visitDate,
+      b?.image,
+    ];
   }
 
   removeBeneficiaryDataForVisit() {
@@ -129,14 +128,10 @@ export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
     this.pharmacistService.getPharmacistWorklist().subscribe(
       (data: any) => {
         if (data && data.statusCode === 200 && data.data) {
-          const benlist = this.loadDataToBenList(data.data);
-          this.beneficiaryList = benlist;
-          this.filterTerm = null;
-          this.setFilteredList(benlist);
+          this.beneficiaryList = this.loadDataToBenList(data.data);
         } else {
           this.confirmationService.alert(data.errorMessage, 'error');
           this.beneficiaryList = [];
-          this.setFilteredList([]);
         }
       },
       err => {
@@ -163,80 +158,6 @@ export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
         'Not Available';
     });
     return data;
-  }
-
-  filterBeneficiaryList(searchTerm: string) {
-    if (!searchTerm) {
-      this.setFilteredList(this.beneficiaryList);
-      return;
-    }
-    const term = searchTerm.toLowerCase();
-    const keys = [
-      'beneficiaryID',
-      'benName',
-      'genderName',
-      'age',
-      'VisitCategory',
-      'benVisitNo',
-      'districtName',
-      'preferredPhoneNum',
-      'villageName',
-      'beneficiaryRegID',
-      'visitDate',
-      'benVisitDate',
-    ];
-    const filtered = this.beneficiaryList.filter((item: any) =>
-      keys.some(key => ('' + item[key]).toLowerCase().indexOf(term) >= 0)
-    );
-    this.setFilteredList(filtered);
-  }
-
-  /** Re-number (sno), reset to first page, and store the visible list. */
-  private setFilteredList(list: any[]) {
-    list.forEach((item: any, index: number) => (item.sno = index + 1));
-    this.filteredBeneficiaryList = list;
-    this.currentPage = 1;
-  }
-
-  get totalPages(): number {
-    return Math.max(
-      1,
-      Math.ceil(this.filteredBeneficiaryList.length / this.pageSize)
-    );
-  }
-
-  get pagedList(): any[] {
-    const start = (this.currentPage - 1) * this.pageSize;
-    return this.filteredBeneficiaryList.slice(start, start + this.pageSize);
-  }
-
-  /** A small window of page numbers around the current page (max 5). */
-  get pageNumbers(): number[] {
-    const total = this.totalPages;
-    let start = Math.max(1, this.currentPage - 2);
-    const end = Math.min(total, start + 4);
-    start = Math.max(1, end - 4);
-    const pages: number[] = [];
-    for (let i = start; i <= end; i++) pages.push(i);
-    return pages;
-  }
-
-  goToPage(page: number) {
-    if (page >= 1 && page <= this.totalPages) this.currentPage = page;
-  }
-
-  prevPage() {
-    if (this.currentPage > 1) this.currentPage--;
-  }
-
-  nextPage() {
-    if (this.currentPage < this.totalPages) this.currentPage++;
-  }
-
-  changePageSize(size: string | string[]) {
-    const value = Array.isArray(size) ? size[0] : size;
-    this.pageSize = Number(value);
-    this.currentPage = 1;
   }
 
   patientImageView(benregID: any) {


### PR DESCRIPTION
Extracts the repeated worklist UI into a single reusable component, `app-beneficiary-worklist`, and refactors the pharmacist worklist onto it as the first consumer.

## Why
Each role's worklist (pharmacist, lab, nurse, doctor, oncologist, radiologist) was a near-identical copy of the same screen — the same search toolbar, `z-card` + `z-table`, client-side filter, pagination and empty state — differing only in columns, cells and the row-click target. That duplication is what SonarCloud flags as "duplicated lines" on each worklist PR after the first.

## What
- **New `app-beneficiary-worklist`** (`core/components/beneficiary-worklist/`) — owns the common chrome: `z-input` search, outline refresh `z-button`, `z-card` + `z-table` (bold headers), client-side filtering (`searchKeys` + optional `extraSearch`), `z-select` rows-per-page + `z-pagination`, and the shadcn in-table empty row. Built entirely from Common-UI primitives.
- **Inputs:** `data`, `headers`, `searchKeys`, `rowTemplate` (projected `<td>` cells), optional `footerStart` (legend/total), label strings. **Outputs:** `rowClick`, `refresh`.
- **Pharmacist worklist** is now a thin wrapper that supplies its columns + row template + `loadPharmaPage`/`loadPharmaWorklist` handlers.

## Behaviour preserved
- No role logic in the shared component — per-role routing, services, data and click destinations are unchanged. A single-role user still sees only their own role (that's app-header, untouched).
- Search, pagination, rows-per-page, row click and image view all behave as before.

## Follow-up
Lab, nurse, doctor, oncologist and radiologist worklists adopt this component next, which removes their duplication too.

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable beneficiary worklist view with built-in search, refresh, pagination, empty-state handling, and row selection.
  * Added support for custom row and footer content, plus configurable labels for a more flexible experience.

* **Refactor**
  * Updated the pharmacist worklist to use the shared worklist view instead of maintaining its own table, filtering, and pagination behavior.
  * Simplified the worklist data flow so the page now focuses on loading and displaying results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->