### PR TITLE
fix(core): show app version from package.json, on one line

### DIFF
--- a/src/app/app-modules/core/components/app-header/app-header.component.html
+++ b/src/app/app-modules/core/components/app-header/app-header.component.html
@@ -100,7 +100,7 @@
     <z-menu #helpMenu="zMenu">
       <button
         z-menu-item
-        class="flex items-center gap-2"
+        class="flex items-center gap-2 whitespace-nowrap"
         (click)="showVersionAndCommitDetails()">
         <ng-icon name="lucideInfo" size="16"></ng-icon>
         {{ currentLanguageSet?.version }} : {{ versionUI }}

--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -23,6 +23,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { environment } from 'src/environments/environment';
+import packageJson from '../../../../../../package.json';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthService, ConfirmationService } from '../../services';
 import { HttpServiceService } from '../../services/http-service.service';
@@ -306,13 +307,14 @@ export class AppHeaderComponent implements OnInit {
     }
   }
   commitDetailsUI: any;
-  versionUI: any;
+  // Displayed app version comes from package.json (single source of truth);
+  // git-version.json is still used for the commit hash in the details dialog.
+  versionUI = packageJson.version;
   getUIVersionAndCommitDetails() {
     const commitDetailsPath: any = 'assets/git-version.json';
     this.auth.getUIVersionAndCommitDetails(commitDetailsPath).subscribe(
       res => {
         this.commitDetailsUI = res;
-        this.versionUI = this.commitDetailsUI['version'];
       },
       err => {}
     );
@@ -330,8 +332,8 @@ export class AppHeaderComponent implements OnInit {
   constructAPIAndUIDetails(apiVersionAndCommitDetails: any) {
     const data = {
       commitDetailsUI: {
-        version: this.commitDetailsUI['version'],
-        commit: this.commitDetailsUI['commit'],
+        version: packageJson.version,
+        commit: this.commitDetailsUI?.['commit'],
       },
       commitDetailsAPI: {
         version: apiVersionAndCommitDetails['git.build.version'] || 'NA',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "importHelpers": true,
     "target": "es5",
     "module": "ES2022",


### PR DESCRIPTION
## What
- The version shown in the header **Help menu** (and the **License Info** dialog) now comes from **package.json** (`versionUI = packageJson.version`) instead of the static `git-version.json`.
- `git-version.json` is kept only for the **commit hash** in the License Info dialog.
- Enabled `resolveJsonModule` in `tsconfig.json` so the JSON import compiles.
- Added `whitespace-nowrap` so **"Version : x.y.z" stays on one line** (it was wrapping).

## Why
`git-version.json` in this repo is a **stale, hand-frozen** asset (its metadata is from a Jul-2023 commit and there's **no script that regenerates it**), so the version/commit it showed were outdated. `package.json` is the maintained source of truth, so the displayed version now tracks it automatically (bump `package.json` per release).

## Files (3)
- `src/app/app-modules/core/components/app-header/app-header.component.ts`
- `src/app/app-modules/core/components/app-header/app-header.component.html`
- `tsconfig.json`

Note: `package.json`'s `version` is left untouched (currently `0.0.0`), so the header will display whatever it holds — bump it to set the shown version.