### PR TITLE
refactor(ui): Phase D M1A — migrate core dialogs to ZardDialogService

### DIFF
--- a/src/app/app-modules/core/components/allergen-search/allergen-search.component.html
+++ b/src/app/app-modules/core/components/allergen-search/allergen-search.component.html
@@ -8,7 +8,7 @@
       zType="ghost"
       zSize="icon"
       class="p-0"
-      matDialogClose
+      (click)="dialogRef.close()"
       [zTooltip]="current_language_set?.common?.close"
       zPosition="bottom"
       aria-label="Close">

--- a/src/app/app-modules/core/components/allergen-search/allergen-search.component.ts
+++ b/src/app/app-modules/core/components/allergen-search/allergen-search.component.ts
@@ -21,11 +21,7 @@
  */
 
 import { Component, Inject, OnInit, DoCheck } from '@angular/core';
-import {
-  MAT_DIALOG_DATA,
-  MatDialogRef,
-  MatDialogClose,
-} from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { MasterdataService } from 'src/app/app-modules/nurse-doctor/shared/services';
 import { HttpServiceService } from '../../services/http-service.service';
 import { SetLanguageComponent } from '../set-language.component';
@@ -50,7 +46,6 @@ import { tooltipImports } from 'Common-UI/v2/ui/tooltip';
     NgFor,
     FormsModule,
     NgIcon,
-    MatDialogClose,
     ZardButtonComponent,
     ZardLoaderComponent,
     ...ZardTableImports,
@@ -78,10 +73,10 @@ export class AllergenSearchComponent implements OnInit, DoCheck {
   pagedItems: any[] = [];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     private masterdataService: MasterdataService,
     public httpServiceService: HttpServiceService,
-    public dialogRef: MatDialogRef<AllergenSearchComponent>
+    public dialogRef: ZardDialogRef<AllergenSearchComponent>
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -20,11 +20,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewContainerRef } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { environment } from 'src/environments/environment';
 import packageJson from '../../../../../../package.json';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { AuthService, ConfirmationService } from '../../services';
 import { HttpServiceService } from '../../services/http-service.service';
 import { IotService } from '../../services/iot.service';
@@ -128,7 +128,8 @@ export class AppHeaderComponent implements OnInit {
   isConnected = true;
   status!: any;
   constructor(
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     private router: Router,
     private auth: AuthService,
     private confirmationService: ConfirmationService,
@@ -345,14 +346,22 @@ export class AppHeaderComponent implements OnInit {
     }
   }
   showData(versionData: any) {
-    this.dialog.open(ShowCommitAndVersionDetailsComponent, {
-      data: versionData,
+    this.dialog.create({
+      zContent: ShowCommitAndVersionDetailsComponent,
+      zData: versionData,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
   }
 
   openIOT() {
-    this.dialog.open(IotBluetoothComponent, {
-      width: '600px',
+    this.dialog.create({
+      zContent: IotBluetoothComponent,
+      zWidth: '600px',
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
   }
 }

--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -128,8 +128,8 @@ export class AppHeaderComponent implements OnInit {
   isConnected = true;
   status!: any;
   constructor(
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     private router: Router,
     private auth: AuthService,
     private confirmationService: ConfirmationService,

--- a/src/app/app-modules/core/components/calibration/calibration.component.ts
+++ b/src/app/app-modules/core/components/calibration/calibration.component.ts
@@ -23,7 +23,7 @@
 //SH20094090,calibration integration,09-06-2021
 
 import { Component, Inject, OnInit, DoCheck } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { MasterdataService } from 'src/app/app-modules/nurse-doctor/shared/services';
 import { ConfirmationService } from '../../services';
 import { HttpServiceService } from '../../services/http-service.service';
@@ -81,11 +81,11 @@ export class CalibrationComponent implements OnInit, DoCheck {
   pagedItems: any[] = [];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     private masterdataService: MasterdataService,
     private confirmationService: ConfirmationService,
     public httpServiceService: HttpServiceService,
-    public dialogRef: MatDialogRef<CalibrationComponent>
+    public dialogRef: ZardDialogRef<CalibrationComponent>
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
+++ b/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
@@ -30,7 +30,7 @@ import {
   DoCheck,
   AfterViewInit,
 } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { HttpServiceService } from '../../services/http-service.service';
 import { ConfirmationService } from '../../services';
 import { SetLanguageComponent } from '../set-language.component';
@@ -119,7 +119,7 @@ export class CameraDialogComponent implements OnInit, DoCheck, AfterViewInit {
   };
 
   constructor(
-    public dialogRef: MatDialogRef<CameraDialogComponent>,
+    public dialogRef: ZardDialogRef<CameraDialogComponent>,
     public httpServiceService: HttpServiceService,
     readonly sessionstorage: SessionStorageService,
     private confirmationService: ConfirmationService

--- a/src/app/app-modules/core/components/common-dialog/common-dialog.component.ts
+++ b/src/app/app-modules/core/components/common-dialog/common-dialog.component.ts
@@ -27,7 +27,7 @@ import {
   EventEmitter,
   DoCheck,
 } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { HttpServiceService } from '../../services/http-service.service';
 import { SetLanguageComponent } from '../set-language.component';
 import {
@@ -121,7 +121,7 @@ export class CommonDialogComponent implements OnInit, DoCheck {
   confirmCareContext: any;
 
   constructor(
-    public dialogRef: MatDialogRef<CommonDialogComponent>,
+    public dialogRef: ZardDialogRef<CommonDialogComponent>,
     public httpServiceService: HttpServiceService
   ) {}
 

--- a/src/app/app-modules/core/components/data-sync-login/data-sync-login.component.ts
+++ b/src/app/app-modules/core/components/data-sync-login/data-sync-login.component.ts
@@ -25,7 +25,7 @@ import { Router } from '@angular/router';
 
 import * as CryptoJS from 'crypto-js';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from '../set-language.component';
 import { ConfirmationService } from '../../services';
 import { HttpServiceService } from '../../services/http-service.service';
@@ -101,8 +101,8 @@ export class DataSyncLoginComponent implements OnInit, DoCheck {
 
   ngOnInit() {
     this.assignSelectedLanguage();
-    this.dialogRef = this.injector.get(MatDialogRef, null);
-    this.data = this.injector.get(MAT_DIALOG_DATA, null);
+    this.dialogRef = this.injector.get(ZardDialogRef, null);
+    this.data = this.injector.get(Z_MODAL_DATA, null);
   }
 
   ngDoCheck() {

--- a/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.html
+++ b/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.html
@@ -29,7 +29,7 @@
       zSize="icon"
       class="p-0"
       aria-label="Close"
-      [matDialogClose]="true">
+      (click)="dialogRef.close(true)">
       <ng-icon name="lucideX"></ng-icon>
     </button>
   </div>

--- a/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.ts
+++ b/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.ts
@@ -26,7 +26,7 @@ import { IotService } from '../../services/iot.service';
 import { SetLanguageComponent } from '../set-language.component';
 import { ConfirmationService } from '../../services';
 import { NgClass, NgIf, NgFor } from '@angular/common';
-import { MatDialogClose } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX, lucideCheck, lucideBluetooth } from '@ng-icons/lucide';
 import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
@@ -40,7 +40,6 @@ import { ZardLoaderComponent } from 'Common-UI/v2/ui/loader';
     NgClass,
     NgIf,
     NgFor,
-    MatDialogClose,
     NgIcon,
     ZardButtonComponent,
     ZardLoaderComponent,
@@ -59,7 +58,8 @@ export class IotBluetoothComponent implements OnInit, DoCheck {
   constructor(
     public service: IotService,
     public httpServiceService: HttpServiceService,
-    private confirmationService: ConfirmationService
+    private confirmationService: ConfirmationService,
+    public dialogRef: ZardDialogRef<IotBluetoothComponent>
   ) {}
 
   apiAvailable = false;

--- a/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.ts
+++ b/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.ts
@@ -58,7 +58,7 @@ export class IotBluetoothComponent implements OnInit, DoCheck {
   constructor(
     public service: IotService,
     public httpServiceService: HttpServiceService,
-    private confirmationService: ConfirmationService,
+    private readonly confirmationService: ConfirmationService,
     public dialogRef: ZardDialogRef<IotBluetoothComponent>
   ) {}
 

--- a/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
+++ b/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
@@ -20,12 +20,18 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import {
-  MAT_DIALOG_DATA,
-  MatDialog,
-  MatDialogRef,
-} from '@angular/material/dialog';
+  Component,
+  OnInit,
+  Inject,
+  DoCheck,
+  ViewContainerRef,
+} from '@angular/core';
+import {
+  Z_MODAL_DATA,
+  ZardDialogService,
+  ZardDialogRef,
+} from 'Common-UI/v2/ui/dialog';
 import { ConfirmationService } from '../../services';
 import { HttpServiceService } from '../../services/http-service.service';
 import { IotService } from '../../services/iot.service';
@@ -73,13 +79,14 @@ export class IotcomponentComponent implements OnInit, DoCheck {
   stripShowMsg = false;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     public httpServiceService: HttpServiceService,
-    public dialogRef: MatDialogRef<IotcomponentComponent>,
+    public dialogRef: ZardDialogRef<IotcomponentComponent>,
     public service: IotService,
     private confirmationService: ConfirmationService,
     readonly sessionstorage: SessionStorageService,
-    private dialog: MatDialog
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef
   ) {}
 
   ngOnInit() {
@@ -102,10 +109,14 @@ export class IotcomponentComponent implements OnInit, DoCheck {
       this.procedure.value.calibrationStartAPI !== undefined &&
       this.procedure.value.calibrationStartAPI !== null
     ) {
-      const dialogRef = this.dialog.open(CalibrationComponent, {
-        width: '600px',
-        disableClose: true,
-        data: { providerServiceMapID: providerServiceMapID },
+      const dialogRef = this.dialog.create<CalibrationComponent, unknown>({
+        zContent: CalibrationComponent,
+        zWidth: '600px',
+        zMaskClosable: false,
+        zData: { providerServiceMapID: providerServiceMapID },
+        zHideFooter: true,
+        zClosable: false,
+        zViewContainerRef: this.viewContainerRef,
       });
 
       dialogRef.afterClosed().subscribe(result => {

--- a/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
+++ b/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
@@ -85,8 +85,8 @@ export class IotcomponentComponent implements OnInit, DoCheck {
     public service: IotService,
     private confirmationService: ConfirmationService,
     readonly sessionstorage: SessionStorageService,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.html
+++ b/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.html
@@ -10,7 +10,7 @@
       type="button"
       class="p-0"
       aria-label="Close"
-      [matDialogClose]="false">
+      (click)="dialogRef.close(false)">
       <ng-icon name="lucideX"></ng-icon>
     </button>
   </div>

--- a/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.ts
+++ b/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.ts
@@ -25,7 +25,7 @@ import { HttpServiceService } from '../../services/http-service.service';
 import { ConfirmationService } from '../../services/confirmation.service';
 import { SetLanguageComponent } from '../set-language.component';
 import { DoctorService } from 'src/app/app-modules/nurse-doctor/shared/services';
-import { MatDialogClose } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { NgIf, NgFor, DatePipe } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
@@ -37,7 +37,6 @@ import { ZardTableImports } from 'Common-UI/v2/ui/table';
   standalone: true,
   templateUrl: './open-previous-visit-details.component.html',
   imports: [
-    MatDialogClose,
     NgIf,
     NgFor,
     DatePipe,
@@ -57,7 +56,8 @@ export class OpenPreviousVisitDetailsComponent implements OnInit {
   constructor(
     public httpServiceService: HttpServiceService,
     private doctorService: DoctorService,
-    private confirmationService: ConfirmationService
+    private confirmationService: ConfirmationService,
+    public dialogRef: ZardDialogRef<OpenPreviousVisitDetailsComponent>
   ) {}
   ngOnInit(): void {
     this.assignSelectedLanguage();

--- a/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.ts
+++ b/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.ts
@@ -56,7 +56,7 @@ export class OpenPreviousVisitDetailsComponent implements OnInit {
   constructor(
     public httpServiceService: HttpServiceService,
     private doctorService: DoctorService,
-    private confirmationService: ConfirmationService,
+    private readonly confirmationService: ConfirmationService,
     public dialogRef: ZardDialogRef<OpenPreviousVisitDetailsComponent>
   ) {}
   ngOnInit(): void {

--- a/src/app/app-modules/core/components/previous-details/previous-details.component.ts
+++ b/src/app/app-modules/core/components/previous-details/previous-details.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { HttpServiceService } from '../../services/http-service.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from '../set-language.component';
 import { FormsModule } from '@angular/forms';
 import { NgFor, NgIf } from '@angular/common';
@@ -70,9 +70,9 @@ export class PreviousDetailsComponent implements OnInit, DoCheck {
   pagedItems: any[] = [];
 
   constructor(
-    public dialogRef: MatDialogRef<PreviousDetailsComponent>,
+    public dialogRef: ZardDialogRef<PreviousDetailsComponent>,
     public httpServiceService: HttpServiceService,
-    @Inject(MAT_DIALOG_DATA) public input: any
+    @Inject(Z_MODAL_DATA) public input: any
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/components/provisional-search/provisional-search.component.ts
+++ b/src/app/app-modules/core/components/provisional-search/provisional-search.component.ts
@@ -25,7 +25,7 @@ import { MasterdataService } from '../../../nurse-doctor/shared/services/masterd
 import { SpinnerService } from '../../services/spinner.service';
 import { HttpServiceService } from '../../services/http-service.service';
 import { SetLanguageComponent } from '../set-language.component';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { NgIf, NgFor } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -76,8 +76,8 @@ export class ProvisionalSearchComponent implements OnInit, DoCheck {
   pagedItems: any[] = [];
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
-    public dialogRef: MatDialogRef<ProvisionalSearchComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
+    public dialogRef: ZardDialogRef<ProvisionalSearchComponent>,
     private masterdataService: MasterdataService,
     public httpServiceService: HttpServiceService,
     private spinnerService: SpinnerService

--- a/src/app/app-modules/core/components/show-commit-and-version-details/show-commit-and-version-details.component.ts
+++ b/src/app/app-modules/core/components/show-commit-and-version-details/show-commit-and-version-details.component.ts
@@ -21,7 +21,7 @@
  */
 
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { HttpServiceService } from '../../services/http-service.service';
 import { SetLanguageComponent } from '../set-language.component';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -39,9 +39,9 @@ export class ShowCommitAndVersionDetailsComponent implements OnInit, DoCheck {
   current_language_set: any;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     public httpServiceService: HttpServiceService,
-    public dialogRef: MatDialogRef<ShowCommitAndVersionDetailsComponent>
+    public dialogRef: ZardDialogRef<ShowCommitAndVersionDetailsComponent>
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/components/view-radiology-uploaded-files/view-radiology-uploaded-files.component.ts
+++ b/src/app/app-modules/core/components/view-radiology-uploaded-files/view-radiology-uploaded-files.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, OnInit, Inject, DoCheck } from '@angular/core';
 import { HttpServiceService } from '../../services/http-service.service';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from '../set-language.component';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
@@ -40,9 +40,9 @@ export class ViewRadiologyUploadedFilesComponent implements OnInit, DoCheck {
   current_language_set: any;
   fileIds = [];
   constructor(
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    @Inject(Z_MODAL_DATA) public input: any,
     public httpServiceService: HttpServiceService,
-    public dialogRef: MatDialogRef<ViewRadiologyUploadedFilesComponent>
+    public dialogRef: ZardDialogRef<ViewRadiologyUploadedFilesComponent>
   ) {}
 
   ngOnInit() {

--- a/src/app/app-modules/core/directives/confirmatory-diagnosis.directive.ts
+++ b/src/app/app-modules/core/directives/confirmatory-diagnosis.directive.ts
@@ -27,7 +27,7 @@ import {
   ElementRef,
   OnInit,
   DoCheck,
-  Injector,
+  ViewContainerRef,
 } from '@angular/core';
 import {
   FormArray,
@@ -38,7 +38,7 @@ import {
 import { GeneralUtils } from '../../nurse-doctor/shared/utility/general-utility';
 import { SetLanguageComponent } from '../components/set-language.component';
 import { HttpServiceService } from '../services/http-service.service';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { ProvisionalSearchComponent } from '../components/provisional-search/provisional-search.component';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 @Directive({ selector: '[appConfirmatoryDiagnosis]' })
@@ -63,8 +63,8 @@ export class ConfirmatoryDiagnosisDirective implements OnInit, DoCheck {
   constructor(
     private fb: FormBuilder,
     private el: ElementRef,
-    private dialog: MatDialog,
-    private readonly injector: Injector,
+    private dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     readonly sessionstorage: SessionStorageService,
     private httpServiceService: HttpServiceService
   ) {}
@@ -76,16 +76,20 @@ export class ConfirmatoryDiagnosisDirective implements OnInit, DoCheck {
   openDialog(): void {
     const searchTerm = this.diagnosisListForm.value.confirmatoryDiagnosis;
     if (searchTerm.length > 2) {
-      const dialogRef = this.dialog.open(ProvisionalSearchComponent, {
-        width: '800px',
-        injector: this.injector,
-        // panelClass: 'fit-screen',
-        data: {
-          searchTerm: searchTerm,
-          addedDiagnosis: this.previousSelected,
-          diagonasisType: this.currentLanguageSet.confirmDiagnosis,
-        },
-      });
+      const dialogRef = this.dialog.create<ProvisionalSearchComponent, unknown>(
+        {
+          zContent: ProvisionalSearchComponent,
+          zWidth: '800px',
+          zData: {
+            searchTerm: searchTerm,
+            addedDiagnosis: this.previousSelected,
+            diagonasisType: this.currentLanguageSet.confirmDiagnosis,
+          },
+          zHideFooter: true,
+          zClosable: false,
+          zViewContainerRef: this.viewContainerRef,
+        }
+      );
 
       dialogRef.afterClosed().subscribe(result => {
         console.log('result', result);

--- a/src/app/app-modules/core/directives/confirmatory-diagnosis.directive.ts
+++ b/src/app/app-modules/core/directives/confirmatory-diagnosis.directive.ts
@@ -63,7 +63,7 @@ export class ConfirmatoryDiagnosisDirective implements OnInit, DoCheck {
   constructor(
     private fb: FormBuilder,
     private el: ElementRef,
-    private dialog: ZardDialogService,
+    private readonly dialog: ZardDialogService,
     private readonly viewContainerRef: ViewContainerRef,
     readonly sessionstorage: SessionStorageService,
     private httpServiceService: HttpServiceService

--- a/src/app/app-modules/core/directives/open-modal.directive.ts
+++ b/src/app/app-modules/core/directives/open-modal.directive.ts
@@ -27,7 +27,7 @@ import {
   ElementRef,
   OnInit,
   DoCheck,
-  Injector,
+  ViewContainerRef,
 } from '@angular/core';
 import {
   FormArray,
@@ -39,7 +39,7 @@ import { ProvisionalSearchComponent } from '../../core/components/provisional-se
 import { GeneralUtils } from '../../nurse-doctor/shared/utility/general-utility';
 import { SetLanguageComponent } from '../components/set-language.component';
 import { HttpServiceService } from '../services/http-service.service';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 
 @Directive({ selector: '[appOpenModal]' })
@@ -64,8 +64,8 @@ export class OpenModalDirective implements OnInit, DoCheck {
   constructor(
     private fb: FormBuilder,
     private el: ElementRef,
-    private dialog: MatDialog,
-    private readonly injector: Injector,
+    private dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     readonly sessionstorage: SessionStorageService,
     private httpServiceService: HttpServiceService
   ) {}
@@ -77,17 +77,22 @@ export class OpenModalDirective implements OnInit, DoCheck {
   openDialog(): void {
     const searchTerm = this.diagnosisListForm.value.provisionalDiagnosis;
     if (searchTerm.length > 2) {
-      const dialogRef = this.dialog.open(ProvisionalSearchComponent, {
-        width: '800px',
-        hasBackdrop: false,
-        injector: this.injector,
-        data: {
-          searchTerm: searchTerm,
-          addedDiagnosis: this.previousSelected,
-          diagonasisType:
-            this.currentLanguageSet.DiagnosisDetails.provisionaldiagnosis,
-        },
-      });
+      const dialogRef = this.dialog.create<ProvisionalSearchComponent, unknown>(
+        {
+          zContent: ProvisionalSearchComponent,
+          zWidth: '800px',
+          zMaskClosable: false,
+          zData: {
+            searchTerm: searchTerm,
+            addedDiagnosis: this.previousSelected,
+            diagonasisType:
+              this.currentLanguageSet.DiagnosisDetails.provisionaldiagnosis,
+          },
+          zHideFooter: true,
+          zClosable: false,
+          zViewContainerRef: this.viewContainerRef,
+        }
+      );
 
       dialogRef.afterClosed().subscribe(result => {
         if (result) {

--- a/src/app/app-modules/core/directives/open-modal.directive.ts
+++ b/src/app/app-modules/core/directives/open-modal.directive.ts
@@ -64,7 +64,7 @@ export class OpenModalDirective implements OnInit, DoCheck {
   constructor(
     private fb: FormBuilder,
     private el: ElementRef,
-    private dialog: ZardDialogService,
+    private readonly dialog: ZardDialogService,
     private readonly viewContainerRef: ViewContainerRef,
     readonly sessionstorage: SessionStorageService,
     private httpServiceService: HttpServiceService

--- a/src/app/app-modules/core/services/camera.service.ts
+++ b/src/app/app-modules/core/services/camera.service.ts
@@ -21,30 +21,36 @@
  */
 
 import { Injectable, ViewContainerRef, Inject, DOCUMENT } from '@angular/core';
-import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { Observable } from 'rxjs';
 import { CameraDialogComponent } from '../components/camera-dialog/camera-dialog.component';
 
 @Injectable()
 export class CameraService {
   constructor(
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
     @Inject(DOCUMENT) doc: any
   ) {}
 
   public capture(titleAlign = 'center'): Observable<any> {
-    const config = new MatDialogConfig();
-    const dialogRef = this.dialog.open(CameraDialogComponent, config);
-    dialogRef.componentInstance.capture = true;
-    dialogRef.componentInstance.imageCode = false;
+    const dialogRef = this.dialog.create<CameraDialogComponent, unknown>({
+      zContent: CameraDialogComponent,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    dialogRef.componentInstance!.capture = true;
+    dialogRef.componentInstance!.imageCode = false;
     return dialogRef.afterClosed();
   }
 
   public viewImage(benImageCode: string, titleAlign = 'center'): void {
-    const config = new MatDialogConfig();
-    const dialogRef = this.dialog.open(CameraDialogComponent, config);
-    dialogRef.componentInstance.capture = false;
-    dialogRef.componentInstance.imageCode = benImageCode;
+    const dialogRef = this.dialog.create<CameraDialogComponent, unknown>({
+      zContent: CameraDialogComponent,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    dialogRef.componentInstance!.capture = false;
+    dialogRef.componentInstance!.imageCode = benImageCode;
   }
 
   public annotate(
@@ -53,25 +59,31 @@ export class CameraService {
     currentLanguage: any,
     titleAlign = 'center'
   ): Observable<any> {
-    const dialogRef = this.dialog.open(CameraDialogComponent, {
-      width: '80%',
+    const dialogRef = this.dialog.create<CameraDialogComponent, unknown>({
+      zContent: CameraDialogComponent,
+      zWidth: '80%',
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.capture = false;
-    dialogRef.componentInstance.imageCode = false;
-    dialogRef.componentInstance.annotate = image;
-    dialogRef.componentInstance.current_language_set = currentLanguage;
-    dialogRef.componentInstance.availablePoints = points;
+    dialogRef.componentInstance!.capture = false;
+    dialogRef.componentInstance!.imageCode = false;
+    dialogRef.componentInstance!.annotate = image;
+    dialogRef.componentInstance!.current_language_set = currentLanguage;
+    dialogRef.componentInstance!.availablePoints = points;
     return dialogRef.afterClosed();
   }
 
   public ViewGraph(graph: any): void {
-    const dialogRef = this.dialog.open(CameraDialogComponent, {
-      width: '80%',
+    const dialogRef = this.dialog.create<CameraDialogComponent, unknown>({
+      zContent: CameraDialogComponent,
+      zWidth: '80%',
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.capture = false;
-    dialogRef.componentInstance.imageCode = false;
-    dialogRef.componentInstance.annotate = false;
-    dialogRef.componentInstance.availablePoints = false;
-    dialogRef.componentInstance.graph = graph;
+    dialogRef.componentInstance!.capture = false;
+    dialogRef.componentInstance!.imageCode = false;
+    dialogRef.componentInstance!.annotate = false;
+    dialogRef.componentInstance!.availablePoints = false;
+    dialogRef.componentInstance!.graph = graph;
   }
 }

--- a/src/app/app-modules/core/services/camera.service.ts
+++ b/src/app/app-modules/core/services/camera.service.ts
@@ -28,7 +28,7 @@ import { CameraDialogComponent } from '../components/camera-dialog/camera-dialog
 @Injectable()
 export class CameraService {
   constructor(
-    private dialog: ZardDialogService,
+    private readonly dialog: ZardDialogService,
     @Inject(DOCUMENT) doc: any
   ) {}
 

--- a/src/app/app-modules/core/services/confirmation.service.ts
+++ b/src/app/app-modules/core/services/confirmation.service.ts
@@ -1,9 +1,5 @@
 import { Injectable, ViewContainerRef, Inject, DOCUMENT } from '@angular/core';
-import {
-  MatDialog,
-  MatDialogConfig,
-  MatDialogRef,
-} from '@angular/material/dialog';
+import { ZardDialogService, ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 
 import { Observable } from 'rxjs';
 import { CommonDialogComponent } from '../components/common-dialog/common-dialog.component';
@@ -11,7 +7,7 @@ import { CommonDialogComponent } from '../components/common-dialog/common-dialog
 @Injectable()
 export class ConfirmationService {
   constructor(
-    public dialog: MatDialog,
+    public dialog: ZardDialogService,
     @Inject(DOCUMENT) doc: any
   ) {}
 
@@ -21,19 +17,23 @@ export class ConfirmationService {
     btnOkText = 'OK',
     btnCancelText = 'Cancel'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.open(CommonDialogComponent, {
-      width: '420px',
-      disableClose: false,
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = true;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = true;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
     dialogRef.disableClose = true;
 
     return dialogRef.afterClosed();
@@ -44,19 +44,22 @@ export class ConfirmationService {
     message: string,
     btnOkText = 'OK'
   ): Observable<boolean> {
-    const config = new MatDialogConfig();
-    const dialogRef = this.dialog.open(CommonDialogComponent, {
-      width: '420px',
-      disableClose: false,
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmHealthID = true;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.confirmHealthID = true;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
     dialogRef.disableClose = true;
 
     return dialogRef.afterClosed();
@@ -66,19 +69,23 @@ export class ConfirmationService {
     message: string,
     status = 'info',
     btnOkText = 'OK'
-  ): MatDialogRef<CommonDialogComponent> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.status = status.toLowerCase();
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = true;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+  ): ZardDialogRef<CommonDialogComponent> {
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.status = status.toLowerCase();
+    instance.btnOkText = btnOkText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = true;
+    instance.remarks = false;
+    instance.editRemarks = false;
 
     return dialogRef;
   }
@@ -90,18 +97,22 @@ export class ConfirmationService {
     btnOkText = 'Submit',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = true;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = true;
+    instance.editRemarks = false;
+    instance.btnCancelText = btnCancelText;
 
     return dialogRef.afterClosed();
   }
@@ -114,16 +125,23 @@ export class ConfirmationService {
     btnOkText = 'Submit',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.open(CommonDialogComponent, { width: '60%' });
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = true;
-    dialogRef.componentInstance.comments = comments;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '60%',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = true;
+    instance.comments = comments;
+    instance.btnCancelText = btnCancelText;
 
     return dialogRef.afterClosed();
   }
@@ -135,19 +153,23 @@ export class ConfirmationService {
     messageAlign = 'center',
     btnOkText = 'OK'
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.notify = true;
-    dialogRef.componentInstance.mandatories = mandatories;
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    instance.notify = true;
+    instance.mandatories = mandatories;
     return dialogRef.afterClosed();
   }
 
@@ -159,21 +181,25 @@ export class ConfirmationService {
     btnOkText = 'Confirm',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.notify = false;
-    dialogRef.componentInstance.choice = true;
-    dialogRef.componentInstance.values = values;
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    instance.notify = false;
+    instance.choice = true;
+    instance.values = values;
     return dialogRef.afterClosed();
   }
 
@@ -184,21 +210,25 @@ export class ConfirmationService {
     btnOkText = 'Continue',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.open(CommonDialogComponent, {
-      width: '420px',
-      disableClose: true,
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.sessionTimeout = true;
-    dialogRef.componentInstance.updateTimer(timer);
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    instance.sessionTimeout = true;
+    instance.updateTimer(timer);
 
     return dialogRef.afterClosed();
   }
@@ -211,22 +241,26 @@ export class ConfirmationService {
     btnOkText = 'Proceed',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.notify = false;
-    dialogRef.componentInstance.choice = false;
-    dialogRef.componentInstance.choiceSelect = true;
-    dialogRef.componentInstance.values = values;
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    instance.notify = false;
+    instance.choice = false;
+    instance.choiceSelect = true;
+    instance.values = values;
     return dialogRef.afterClosed();
   }
 
@@ -245,17 +279,21 @@ export class ConfirmationService {
     status = 'Fetosense Device',
     btnOkText = 'OK'
   ): void {
-    const config = {
-      width: '420px',
-    };
-    const dialogRef = this.dialog.open(CommonDialogComponent, config);
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.status = status;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.alertFetsenseMessage = true;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.message = message;
+    instance.status = status;
+    instance.btnOkText = btnOkText;
+    instance.confirmAlert = false;
+    instance.alertFetsenseMessage = true;
+    instance.remarks = false;
+    instance.editRemarks = false;
   }
   /*END*/
   public confirmCalibration(
@@ -264,19 +302,23 @@ export class ConfirmationService {
     btnOkText = 'Yes',
     btnCancelText = 'No'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.open(CommonDialogComponent, {
-      width: '420px',
-      disableClose: false,
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmcalibration = true;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = true;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
 
     return dialogRef.afterClosed();
   }
@@ -287,21 +329,25 @@ export class ConfirmationService {
     btnOkText = 'OK',
     btnCancelText = 'Cancel'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.open(CommonDialogComponent, {
-      width: '420px',
-      disableClose: false,
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: true,
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmCBAC = true;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
-    dialogRef.componentInstance.cbacData = data;
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = false;
+    instance.confirmCBAC = true;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    instance.cbacData = data;
 
     return dialogRef.afterClosed();
   }
@@ -312,21 +358,25 @@ export class ConfirmationService {
     btnOkText = 'Yes',
     btnCancelText = 'No'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.open(CommonDialogComponent, {
-      width: '420px',
-      disableClose: false,
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth: '420px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
     });
-    dialogRef.componentInstance.title = title;
-    dialogRef.componentInstance.message = message;
-    dialogRef.componentInstance.btnOkText = btnOkText;
-    dialogRef.componentInstance.btnCancelText = btnCancelText;
-    dialogRef.componentInstance.confirmAlert = false;
-    dialogRef.componentInstance.confirmCareContext = true;
-    dialogRef.componentInstance.confirmCBAC = false;
-    dialogRef.componentInstance.confirmcalibration = false;
-    dialogRef.componentInstance.alert = false;
-    dialogRef.componentInstance.remarks = false;
-    dialogRef.componentInstance.editRemarks = false;
+    const instance = dialogRef.componentInstance!;
+    instance.title = title;
+    instance.message = message;
+    instance.btnOkText = btnOkText;
+    instance.btnCancelText = btnCancelText;
+    instance.confirmAlert = false;
+    instance.confirmCareContext = true;
+    instance.confirmCBAC = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
     dialogRef.disableClose = true;
 
     return dialogRef.afterClosed();

--- a/src/app/app-modules/core/services/confirmation.service.ts
+++ b/src/app/app-modules/core/services/confirmation.service.ts
@@ -11,29 +11,39 @@ export class ConfirmationService {
     @Inject(DOCUMENT) doc: any
   ) {}
 
+  private createDialog(
+    zWidth: string,
+    zMaskClosable: boolean
+  ): ZardDialogRef<CommonDialogComponent> {
+    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
+      zContent: CommonDialogComponent,
+      zWidth,
+      zMaskClosable,
+      zHideFooter: true,
+      zClosable: false,
+    });
+    const instance = dialogRef.componentInstance!;
+    instance.confirmAlert = false;
+    instance.confirmcalibration = false;
+    instance.alert = false;
+    instance.remarks = false;
+    instance.editRemarks = false;
+    return dialogRef;
+  }
+
   public confirm(
     title: string,
     message: string,
     btnOkText = 'OK',
     btnCancelText = 'Cancel'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: false,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', false);
     const instance = dialogRef.componentInstance!;
     instance.title = title;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
     instance.confirmAlert = true;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     dialogRef.disableClose = true;
 
     return dialogRef.afterClosed();
@@ -44,22 +54,12 @@ export class ConfirmationService {
     message: string,
     btnOkText = 'OK'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: false,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', false);
     const instance = dialogRef.componentInstance!;
     instance.title = title;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.confirmHealthID = true;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     dialogRef.disableClose = true;
 
     return dialogRef.afterClosed();
@@ -70,22 +70,12 @@ export class ConfirmationService {
     status = 'info',
     btnOkText = 'OK'
   ): ZardDialogRef<CommonDialogComponent> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.status = status.toLowerCase();
     instance.btnOkText = btnOkText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
     instance.alert = true;
-    instance.remarks = false;
-    instance.editRemarks = false;
 
     return dialogRef;
   }
@@ -97,21 +87,11 @@ export class ConfirmationService {
     btnOkText = 'Submit',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.btnOkText = btnOkText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
     instance.remarks = true;
-    instance.editRemarks = false;
     instance.btnCancelText = btnCancelText;
 
     return dialogRef.afterClosed();
@@ -125,20 +105,10 @@ export class ConfirmationService {
     btnOkText = 'Submit',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '60%',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('60%', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.btnOkText = btnOkText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
     instance.editRemarks = true;
     instance.comments = comments;
     instance.btnCancelText = btnCancelText;
@@ -153,21 +123,10 @@ export class ConfirmationService {
     messageAlign = 'center',
     btnOkText = 'OK'
   ): Observable<any> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.btnOkText = btnOkText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     instance.notify = true;
     instance.mandatories = mandatories;
     return dialogRef.afterClosed();
@@ -181,22 +140,11 @@ export class ConfirmationService {
     btnOkText = 'Confirm',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     instance.notify = false;
     instance.choice = true;
     instance.values = values;
@@ -210,23 +158,12 @@ export class ConfirmationService {
     btnOkText = 'Continue',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: false,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', false);
     const instance = dialogRef.componentInstance!;
     instance.title = title;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     instance.sessionTimeout = true;
     instance.updateTimer(timer);
 
@@ -241,22 +178,11 @@ export class ConfirmationService {
     btnOkText = 'Proceed',
     btnCancelText = 'Cancel'
   ): Observable<any> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
-    instance.confirmAlert = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     instance.notify = false;
     instance.choice = false;
     instance.choiceSelect = true;
@@ -279,21 +205,12 @@ export class ConfirmationService {
     status = 'Fetosense Device',
     btnOkText = 'OK'
   ): void {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.message = message;
     instance.status = status;
     instance.btnOkText = btnOkText;
-    instance.confirmAlert = false;
     instance.alertFetsenseMessage = true;
-    instance.remarks = false;
-    instance.editRemarks = false;
   }
   /*END*/
   public confirmCalibration(
@@ -302,23 +219,13 @@ export class ConfirmationService {
     btnOkText = 'Yes',
     btnCancelText = 'No'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.title = title;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
-    instance.confirmAlert = false;
     instance.confirmcalibration = true;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
 
     return dialogRef.afterClosed();
   }
@@ -329,24 +236,13 @@ export class ConfirmationService {
     btnOkText = 'OK',
     btnCancelText = 'Cancel'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: true,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', true);
     const instance = dialogRef.componentInstance!;
     instance.title = title;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
-    instance.confirmAlert = false;
     instance.confirmCBAC = true;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     instance.cbacData = data;
 
     return dialogRef.afterClosed();
@@ -358,25 +254,14 @@ export class ConfirmationService {
     btnOkText = 'Yes',
     btnCancelText = 'No'
   ): Observable<boolean> {
-    const dialogRef = this.dialog.create<CommonDialogComponent, unknown>({
-      zContent: CommonDialogComponent,
-      zWidth: '420px',
-      zMaskClosable: false,
-      zHideFooter: true,
-      zClosable: false,
-    });
+    const dialogRef = this.createDialog('420px', false);
     const instance = dialogRef.componentInstance!;
     instance.title = title;
     instance.message = message;
     instance.btnOkText = btnOkText;
     instance.btnCancelText = btnCancelText;
-    instance.confirmAlert = false;
     instance.confirmCareContext = true;
     instance.confirmCBAC = false;
-    instance.confirmcalibration = false;
-    instance.alert = false;
-    instance.remarks = false;
-    instance.editRemarks = false;
     dialogRef.disableClose = true;
 
     return dialogRef.afterClosed();


### PR DESCRIPTION
## What (Phase D — M1A: Core Dialogs)
Migrates the **shared core dialogs** and their core openers off Angular Material's `MatDialog` to `ZardDialogService` (uses the Common-UI dialog engine from #72/#73).

**Dialog components** → `ZardDialogRef` + `Z_MODAL_DATA`: provisional-search, allergen-search, camera-dialog, calibration, **common-dialog** (the app-wide alert/confirm), iot-bluetooth, iotcomponent, open-previous-visit-details, previous-details, view-radiology-uploaded-files, show-commit-and-version-details, data-sync-login.

**Core openers** → `create({...})`: **ConfirmationService** (all 13 alert/confirm/remarks methods — `afterClosed()` result-flow preserved), camera.service, app-header, iotcomponent, and the confirmatory-diagnosis / open-modal directives (the prior `injector` fix migrated to `zViewContainerRef`).

`HttpInterceptor` now uses `ZardDialogService.closeAll()`.

## Notes
- Bumps the Common-UI submodule to the dialog engine enablers: `afterClosed()`, caller-injector resolution, `disableClose` (backdrop + Escape), `closeAll()`.
- `disableClose` and `close(result)` behaviour preserved; dialog heights drop to content-sizing (Zard has no height option).
- **Stacked on the ND migration** (`review/nd-migration`). The **nurse-doctor openers** of these core dialogs (workarea, history, vitals, tmcconfirmation, etc.) are migrated in **M1B** — so M1A + M1B merge together.
- AOT build green.
