### PR TITLE
style(ui): Phase D follow-up — re-enable Tailwind Preflight + drop button workarounds

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2,49 +2,6 @@
 /* NOTE: css/custom.css and css/layout.css are loaded via angular.json `styles`
    (not @import here) so Tailwind's PostCSS bundler doesn't rewrite their url()s. */
 
-/* Material's prebuilt theme ships an unlayered "button border-radius 0" rule
-   (and the browser sets a native button appearance) that override Tailwind's
-   layered radius and appearance utilities. So every Zard control built on a
-   button element (the button itself AND the z-select trigger, a button with
-   role="combobox") renders square with the native look. These attribute
-   selectors outrank bare "button" and, being unlayered, beat Material/Bootstrap,
-   restoring the theme radius so they match inputs.
-   REMOVE this block once Material is removed and Tailwind preflight is enabled. */
-[z-button],
-z-select [role='combobox'] {
-  -webkit-appearance: none;
-  appearance: none;
-  border-radius: var(--radius);
-}
-
-/* z-accordion-trigger renders a bare <button> whose base classes never reset
-   appearance/border (they rely on Tailwind preflight, which is OFF here). So the
-   browser's native button border + Material's unlayered button{border-radius:0}
-   paint a square, boxed outline over the accordion item, making the rounded
-   border-border/bg-card item look like a black square. Zero the trigger button
-   so only the item's own rounded border shows. */
-z-accordion-trigger button,
-[z-accordion-trigger] button {
-  -webkit-appearance: none;
-  appearance: none;
-  border: 0;
-  background: transparent;
-}
-
-/* z-pagination-button is a wrapper <button> around the actual <z-button>.
-   With preflight off, that bare wrapper shows the browser's native button
-   border + background (appearance:none alone doesn't clear them, and unlike a
-   real z-button it has no border-transparent/bg class). Zero it fully so only
-   the inner Zard button (ghost prev/next, outline active page) is visible. */
-[z-pagination-button] {
-  -webkit-appearance: none;
-  appearance: none;
-  border: 0;
-  background: transparent;
-  padding: 0;
-}
-
-
 /* Lato Font - Local */
 @font-face {
   font-family: 'Lato';

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,15 +1,17 @@
 /* ===== AMRIT Tailwind v4 + ZardUI theme =====
    Loaded as its own entry in angular.json so it doesn't pull existing app CSS
    (custom.css/layout.css) through Tailwind's @import bundler.
-   Bootstrap and Angular Material are now removed from the app. Tailwind's
-   Preflight (the global base reset) is still intentionally NOT imported: turning
-   it on flips a global element reset that needs a visual pass across every
-   screen (notably the Zard select-trigger radius vs inputs/buttons), so it is
-   handled in a dedicated follow-up. Utilities live in the highest layer; the
-   unlayered legacy CSS (custom.css/layout.css/styles.css) still overrides them.
+   Bootstrap and Angular Material are removed, so Tailwind's Preflight (the global
+   base reset) is now enabled in the low-priority `base` layer. Cascade order:
+   base < components < utilities < unlayered legacy CSS (custom.css/layout.css/
+   styles.css) — so legacy screens keep their explicit styling, utilities win on
+   migrated markup, and Preflight only supplies the base reset for bare elements
+   (normalising buttons, lists, headings, tables) that previously relied on the
+   browser default or the removed Material/Bootstrap resets.
    AMRIT blue + white tokens drive ZardUI components from Common-UI/v2/ui. */
-@layer theme, components, utilities;
+@layer theme, base, components, utilities;
 @import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/preflight.css' layer(base);
 @import 'tailwindcss/utilities.css' layer(utilities);
 @plugin 'tailwindcss-animate';
 @source '../Common-UI/v2/ui';


### PR DESCRIPTION
## Phase D follow-up — re-enable Tailwind Preflight + drop the button workarounds

Stacked on the Material/Bootstrap-removal PR (#414). Now that Angular Material and Bootstrap are fully gone, this turns Tailwind's **Preflight** (global base reset) back on and removes the coexistence hacks that only existed because it was off.

### Changes
- **`src/tailwind.css`** — import `tailwindcss/preflight.css` into a low-priority `base` layer (`@layer theme, base, components, utilities`). Cascade: `base < components < utilities < unlayered legacy CSS` — legacy screens keep their explicit styling, utilities win on migrated markup, and Preflight only supplies the base reset for bare elements.
- **`src/styles.css`** — remove the three obsolete button workarounds:
  - `[z-button], z-select [role='combobox']` appearance/radius reset
  - `z-accordion-trigger button` border/background reset
  - `[z-pagination-button]` reset

  These countered Material's unlayered `button{border-radius:0}` + the missing base reset. Preflight now provides all of it: its `*` rule zeroes `margin`/`padding`/`border`, and it normalises `button` appearance and `ul/ol` list-style. (Verified against `node_modules/tailwindcss/preflight.css`.)
- **Common-UI submodule bump** — `z-select` wrapper + trigger radius `rounded-md → rounded-lg`, so the select matches `z-input`/`z-button` (`rounded-lg` = `var(--radius)` = 10px) once the radius-forcing hack is gone.

### Also fixes
The known worklist pagination cosmetic bug (stray `•` bullets + native-box prev/next): Preflight removes `ul` list-style and normalises the wrapper `<button>`, so it renders as intended without the `[z-pagination-button]` hack.

### ⚠️ Requires visual QA before merge
Preflight is a **global element reset** affecting every screen. AOT build is green, but a headless CI can't verify appearance. Before merging, eyeball a representative set on a running instance:
- form controls (inputs, **z-select trigger radius vs inputs/buttons**, buttons, checkboxes/radios)
- worklist tables + **pagination** (bullets gone, ghost prev/next)
- an **accordion** and a **dialog** (buttons, close-X)
- any screen still relying on `custom.css`/`layout.css` (headings, lists, tables) — these are unlayered so they should win over Preflight, but confirm no heading/list/table spacing regressions.

Material/Bootstrap are gone regardless of this PR — Preflight is an internal reset toggle, not a framework dependency.
