### PR TITLE
build(deps): Goal 11 — modernize charting (ng2-charts 5 to 9 + standalone API)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jquery": "^3.7.1",
         "moment": "^2.30.1",
         "ng-cryptostore": "^16.0.0",
-        "ng2-charts": "^5.0.4",
+        "ng2-charts": "^9.0.0",
         "ngx-cookie-service": "^20.1.1",
         "ngx-pagination": "^6.0.3",
         "ngx-sonner": "^3.1.0",
@@ -16777,19 +16777,19 @@
       }
     },
     "node_modules/ng2-charts": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-5.0.4.tgz",
-      "integrity": "sha512-AnOZ2KSRw7QjiMMNtXz9tdnO+XrIKP/2MX1TfqEEo2fwFU5c8LFJIYqmkMPkIzAEm/U9y/1psA5TDNmxxjEdgA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-9.0.0.tgz",
+      "integrity": "sha512-oG4VLbwDmWtSCaBoiuoi14LZR2DrOgG5WKtGm12eAQHrA32l0dc0XwKurY/dilc9bgKAiJgL/qy2hy/rcb8yog==",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.15",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": ">=16.0.0",
-        "@angular/common": ">=16.0.0",
-        "@angular/core": ">=16.0.0",
-        "@angular/platform-browser": ">=16.0.0",
+        "@angular/cdk": ">=20.0.0",
+        "@angular/common": ">=20.0.0",
+        "@angular/core": ">=20.0.0",
+        "@angular/platform-browser": ">=20.0.0",
         "chart.js": "^3.4.0 || ^4.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery": "^3.7.1",
     "moment": "^2.30.1",
     "ng-cryptostore": "^16.0.0",
-    "ng2-charts": "^5.0.4",
+    "ng2-charts": "^9.0.0",
     "ngx-cookie-service": "^20.1.1",
     "ngx-pagination": "^6.0.3",
     "ngx-sonner": "^3.1.0",

--- a/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
+++ b/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
@@ -43,7 +43,7 @@ import { saveAs } from 'file-saver';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { NgIf, NgFor } from '@angular/common';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { NgChartsModule } from 'ng2-charts';
+import { BaseChartDirective } from 'ng2-charts';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
 import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
@@ -67,7 +67,7 @@ interface Mark {
     WebcamModule,
     ReactiveFormsModule,
     FormsModule,
-    NgChartsModule,
+    BaseChartDirective,
     NgIcon,
     ZardButtonComponent,
     ZardInputDirective,

--- a/src/app/app-modules/nurse-doctor/case-record/cancer-case-record/cancer-case-record.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/cancer-case-record/cancer-case-record.component.ts
@@ -38,7 +38,7 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { BeneficiaryPlatformHistoryComponent } from '../beneficiary-platform-history/beneficiary-platform-history.component';
 import { NgClass, NgIf } from '@angular/common';
-import { NgChartsModule } from 'ng2-charts';
+import { BaseChartDirective } from 'ng2-charts';
 import { StringValidatorDirective } from '../../../core/directives/stringValidator.directive';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideFile } from '@ng-icons/lucide';
@@ -55,7 +55,7 @@ import { ZardButtonComponent } from 'Common-UI/v2/ui/button';
     BeneficiaryPlatformHistoryComponent,
     NgClass,
     NgIf,
-    NgChartsModule,
+    BaseChartDirective,
     StringValidatorDirective,
     NgIcon,
     ...ZardAccordionImports,

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/previous-visit-details/previous-visit-details.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/previous-visit-details/previous-visit-details.component.ts
@@ -29,7 +29,7 @@ import { Router } from '@angular/router';
 import { SessionStorageService } from 'Common-UI/v2/registrar/services/session-storage.service';
 import { BeneficiaryPlatformHistoryComponent } from '../../beneficiary-platform-history/beneficiary-platform-history.component';
 import { NgClass, NgIf } from '@angular/common';
-import { NgChartsModule } from 'ng2-charts';
+import { BaseChartDirective } from 'ng2-charts';
 import { cardImports } from 'Common-UI/v2/ui/card';
 @Component({
   selector: 'app-previous-visit-details',
@@ -38,7 +38,7 @@ import { cardImports } from 'Common-UI/v2/ui/card';
     BeneficiaryPlatformHistoryComponent,
     NgClass,
     NgIf,
-    NgChartsModule,
+    BaseChartDirective,
     ...cardImports,
   ],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { provideRouter, withHashLocation } from '@angular/router';
 import { routes } from './app/app.routes';
 import { WebcamModule } from 'ngx-webcam';
 import { NgxPaginationModule } from 'ngx-pagination';
-import { NgChartsModule } from 'ng2-charts';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import { TrackingModule } from 'Common-UI/v2/tracking';
 import { provideZard } from 'Common-UI/v2/ui/provider';
 import { AppComponent } from './app/app.component';
@@ -49,9 +49,9 @@ bootstrapApplication(AppComponent, {
       ReactiveFormsModule,
       WebcamModule,
       NgxPaginationModule,
-      NgChartsModule,
       TrackingModule.forRoot()
     ),
+    provideCharts(withDefaultRegisterables()),
     provideRouter(routes, withHashLocation()),
     // Zard custom event-manager plugins ({key} multi-key + .debounce template syntax).
     provideZard(),


### PR DESCRIPTION
## Modernize charting: ng2-charts 5 → 9 + standalone API (Goal 11)

The app was on **ng2-charts 5.0.4 — built for Angular 16** — while running Angular 20, using the legacy `NgChartsModule`. This upgrades to the Angular-20-matched **ng2-charts 9.0.0** and moves to its modern standalone integration. **Chart.js stays at 4.4.2** (already current; ng2-charts 9 peer-deps `chart.js ^3||^4`).

### Changes
- **package.json** — `ng2-charts ^5.0.4 → ^9.0.0` (resolves the Angular-major mismatch).
- **src/main.ts** — dropped `importProvidersFrom(NgChartsModule)`; added `provideCharts(withDefaultRegisterables())` (the v9 way to register Chart.js controllers/elements app-wide).
- **3 chart components** (`camera-dialog`, `cancer-case-record`, `previous-visit-details`) — replaced the `NgChartsModule` import with the **standalone `BaseChartDirective`** in their `imports` arrays.
- **Templates + chart data/options: unchanged** — v9 keeps the same `canvas[baseChart]` selector and `[data]`/`[type]`/`[options]`/`[labels]`/`[datasets]` inputs, so no chart config was touched.

### Why this is "modern"
`NgChartsModule` is removed in ng2-charts 9; the current pattern is the tree-shakable standalone `BaseChartDirective` + explicit `provideCharts(...)` registration — consistent with the app's standalone architecture. This also brings ng2-charts back in lockstep with the Angular 20 runtime.

### ⚠️ Requires visual QA before merge
AOT build is green, but the charts render on canvas and **can't be verified headless in CI**. Before merging, eyeball the trend charts on:
- **Cancer case-record** — weight / BP (systolic+diastolic) / blood-glucose line charts,
- **General case-record → previous visit details** — the same BG/vitals trend charts,
- **Camera dialog** — its chart.

Confirm they render with data, axes, and legends as before. (Chart.js registration moved from `NgChartsModule`'s implicit registration to `withDefaultRegisterables()`, which registers all controllers — so functionally equivalent.)
